### PR TITLE
feat(codex): add filesystem permission profiles

### DIFF
--- a/chezmoi/.chezmoitemplates/codex-defaults.toml
+++ b/chezmoi/.chezmoitemplates/codex-defaults.toml
@@ -6,7 +6,6 @@
 
 approval_policy = "on-request"
 approvals_reviewer = "auto_review"
-sandbox_mode = "workspace-write"
 service_tier = "default"
 model = "gpt-5.6-luna"
 model_reasoning_effort = "max"
@@ -44,6 +43,16 @@ experimental_mode = true
 
 [permissions.default-permissions]
 extends = ":workspace"
+
+# Permission profiles are beta and may change with Codex releases.
+# :root denies broad filesystem access; :minimal keeps the platform/runtime
+# paths required by common tools readable. Revalidate this policy on upgrades.
+# Configuration shape checked with Codex CLI 0.153.4; runtime canary remains
+# part of Issue #16 completion.
+# Reference: https://learn.chatgpt.com/docs/permissions
+[permissions.default-permissions.filesystem]
+":root" = "deny"
+":minimal" = "read"
 
 [permissions.default-permissions.network]
 enabled = true

--- a/chezmoi/.chezmoitemplates/codex-defaults.toml.local.example
+++ b/chezmoi/.chezmoitemplates/codex-defaults.toml.local.example
@@ -2,6 +2,8 @@
 # The .local file is ignored by Git and merged after codex-defaults.toml.
 # A shared checkout reads this file on both Windows and WSL, so keep values
 # valid on both systems; put WSL-only setup under codex-wsl/ instead.
+# Legacy sandbox_mode and sandbox_workspace_write keys are removed by the
+# modify template; Permission Profiles remain authoritative.
 # Do not put credentials here; keep authentication in CODEX_HOME/auth.json.
 
 # Example:

--- a/chezmoi/.chezmoitemplates/codex-personal-defaults.toml
+++ b/chezmoi/.chezmoitemplates/codex-personal-defaults.toml
@@ -43,6 +43,16 @@ experimental_mode = true
 [permissions.personal-standard]
 extends = ":workspace"
 
+# Permission profiles are beta and may change with Codex releases.
+# :root denies broad filesystem access; :minimal keeps the platform/runtime
+# paths required by common tools readable. Revalidate this policy on upgrades.
+# Configuration shape checked with Codex CLI 0.153.4; runtime canary remains
+# part of Issue #16 completion.
+# Reference: https://learn.chatgpt.com/docs/permissions
+[permissions.personal-standard.filesystem]
+":root" = "deny"
+":minimal" = "read"
+
 [permissions.personal-standard.network]
 enabled = true
 

--- a/chezmoi/.chezmoitemplates/codex-personal-defaults.toml.local.example
+++ b/chezmoi/.chezmoitemplates/codex-personal-defaults.toml.local.example
@@ -4,6 +4,8 @@
 #
 # Replace <user> with the Windows account name. These paths are intentionally
 # host-local; keep WSL settings in the separate codex-wsl home instead.
+# Legacy sandbox_mode and sandbox_workspace_write keys are removed by the
+# modify template; Permission Profiles remain authoritative.
 # Do not put credentials here; keep authentication in CODEX_HOME/auth.json.
 
 [permissions.personal-standard.filesystem]

--- a/chezmoi/dot_codex-personal/modify_config.toml
+++ b/chezmoi/dot_codex-personal/modify_config.toml
@@ -15,6 +15,9 @@ migration. auth.json is a separate file and is never read or written here.
 {{- if hasKey $config "sandbox_mode" -}}
 {{-   $config = unset $config "sandbox_mode" -}}
 {{- end -}}
+{{- if hasKey $config "sandbox_workspace_write" -}}
+{{-   $config = unset $config "sandbox_workspace_write" -}}
+{{- end -}}
 {{- if hasKey $config "permissions" -}}
 {{-   $permissions := index $config "permissions" -}}
 {{-   if hasKey $permissions "default-permissions" -}}
@@ -34,6 +37,9 @@ migration. auth.json is a separate file and is never read or written here.
 {{- end -}}
 {{- if hasKey $defaults "sandbox_mode" -}}
 {{-   $defaults = unset $defaults "sandbox_mode" -}}
+{{- end -}}
+{{- if hasKey $defaults "sandbox_workspace_write" -}}
+{{-   $defaults = unset $defaults "sandbox_workspace_write" -}}
 {{- end -}}
 {{- if hasKey $defaults "permissions" -}}
 {{-   $defaultPermissions := index $defaults "permissions" -}}

--- a/chezmoi/dot_codex/modify_config.toml
+++ b/chezmoi/dot_codex/modify_config.toml
@@ -5,6 +5,8 @@ Manage only stable, portable work Codex settings. The existing target config
 is parsed first and overlaid with repository defaults, so Codex-managed
 projects, hook state, model availability state, and unknown keys are kept.
 An optional codex-defaults.toml.local file can add host-specific values.
+Legacy sandbox settings are removed because permission profiles and
+sandbox_mode/sandbox_workspace_write are mutually exclusive.
 auth.json is a separate file and is never read or written here.
 
 */ -}}
@@ -13,11 +15,23 @@ auth.json is a separate file and is never read or written here.
 {{- if $stdin -}}
 {{-   $config = fromToml $stdin -}}
 {{- end -}}
+{{- if hasKey $config "sandbox_mode" -}}
+{{-   $config = unset $config "sandbox_mode" -}}
+{{- end -}}
+{{- if hasKey $config "sandbox_workspace_write" -}}
+{{-   $config = unset $config "sandbox_workspace_write" -}}
+{{- end -}}
 {{- $defaults := fromToml (include ".chezmoitemplates/codex-defaults.toml") -}}
 {{- $localDefaultsPath := printf "%s/.chezmoitemplates/codex-defaults.toml.local" .chezmoi.sourceDir -}}
 {{- if (stat $localDefaultsPath) -}}
 {{-   $local := fromToml (include ".chezmoitemplates/codex-defaults.toml.local") -}}
 {{-   $defaults = mergeOverwrite $defaults $local -}}
+{{- end -}}
+{{- if hasKey $defaults "sandbox_mode" -}}
+{{-   $defaults = unset $defaults "sandbox_mode" -}}
+{{- end -}}
+{{- if hasKey $defaults "sandbox_workspace_write" -}}
+{{-   $defaults = unset $defaults "sandbox_workspace_write" -}}
 {{- end -}}
 {{- $config = mergeOverwrite $config $defaults -}}
 {{ $config | toToml }}


### PR DESCRIPTION
## Summary

- Add `":root" = "deny"` and `":minimal" = "read"` to the work and personal filesystem permission profiles.
- Remove legacy `sandbox_mode` and `[sandbox_workspace_write]` settings while rendering managed configs so they do not coexist with Permission Profiles.
- Preserve host-local explicit exceptions and leave blanket `tmp` denial out of scope.
- Record the `:minimal` rationale, Codex CLI 0.153.4 check target, and revalidation guidance beside the settings.

## Validation

- Rendered the current work and personal configs through the chezmoi modify templates.
- Confirmed both profiles contain `:root` deny and `:minimal` read.
- Confirmed legacy sandbox settings are absent from rendered output.
- `git diff --check` passed.
- Commit hook secret scan passed.

## Follow-up verification

- [ ] Native Windows CLI: verify workspace read/write, outside-workspace read denial, and explicit exceptions.
- [ ] Native Windows Desktop: repeat the same permission checks through the Desktop path.
- [ ] WSL CLI: repeat the same permission checks and representative development-tool smoke tests.
- [ ] In each applicable path, verify symlink / junction / `..` traversal cannot bypass outside-workspace denial.

Desktop-to-WSL operation is outside the default canary scope; if that deployment path is used, add it to the verification before closing Issue #16.

Runtime canary results are aggregated in [Issue #16](https://github.com/the9ball/.dotfiles/issues/16), which is the source of truth for the final pass/close decision. PR #17 may be merged after code review before the canary is complete; merging this PR does not close the Issue.

References: #16

Configuration reference: https://learn.chatgpt.com/docs/permissions