### PR TITLE
feat(task-complete-notify): add one-shot completion notification skill

### DIFF
--- a/.agents/skills/task-complete-notify/SKILL.md
+++ b/.agents/skills/task-complete-notify/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: task-complete-notify
+description: Use when the user explicitly asks to arm a one-shot ntfy notification for a selected Codex thread.
+---
+
+# Task-complete notification
+
+Use this skill only when the user explicitly asks to arm a task-completion notification. It is a best-effort notification for one explicitly selected Codex thread; it does not infer the current thread and it does not inspect prompts or logs to compose notification text.
+
+## Scope
+
+The first adapter is Codex on Windows. Runtime state is isolated under the
+resolved Codex home as `$CODEX_HOME\.task-complete-notify` (or the user's
+`.codex` home when `CODEX_HOME` is unset), so separate homes such as
+`.codex` and `.codex-personal` never share requests or locks. WSL callers must
+use the Windows PowerShell helper for all state and lock operations and must
+inherit the active session's `CODEX_HOME`.
+
+The Codex `Stop` hook is the primary completion detector. Register it manually in the user's Codex hook configuration after reviewing the generated command and running the canary described below. The JSONL watcher is a fallback only when the Stop-hook canary is not viable; do not enable both as independent senders.
+
+## Permission prerequisites
+
+The skill does not edit Codex configuration or select a permission profile. Before
+enabling the hook or fallback watcher, verify the exact profile and sandbox used
+by the target session. The minimum required access is read-only access to the
+same home's `session_index.jsonl` and rollout files, write access only to that
+home's `$CODEX_HOME\.task-complete-notify`, and HTTPS access to `ntfy.sh`.
+Do not broaden access to an entire user profile or filesystem. A canary run
+through the exact production hook path must establish whether profile and
+legacy sandbox enforcement apply to the child process.
+
+## Arm a notification
+
+For a Windows PowerShell caller, run:
+
+```powershell
+pwsh.exe -NoProfile -NonInteractive -File "<skill-dir>\scripts\arm-notification.ps1" `
+  -Thread "codex://threads/<UUID>" `
+  -Message "Build finished"
+```
+
+The canonical target is `codex://threads/<UUID>`. An arm input may contain a
+raw UUID or canonical URI inside ordinary labels, quotes, Markdown, or other
+surrounding text. UUID candidates use ASCII hexadecimal D-form (`8-4-4-4-12`)
+with standalone ASCII boundaries; repeated occurrences of the same UUID are
+allowed, but two different candidates are rejected as `thread_ambiguous`.
+Inputs over 4 KiB UTF-8, zero candidates, invalid UUIDs, the legacy
+`codex://<UUID>` form, and URI path/query/fragment decorations are rejected.
+Only the arm boundary uses this relaxed extraction. Hook input, transcript
+metadata, state, and watcher values continue to require the strict complete
+canonical/raw form.
+
+Before an arm request creates state, the helper verifies that the target is
+managed by the current Codex home: an exact `session_index.jsonl` ID match and
+an active rollout whose first `session_meta` has matching `id` and
+`session_id`, `thread_source: "user"`, and no parent fields. Unknown,
+archived, or other-home IDs fail closed as `thread_not_managed` and do not
+create `.task-complete-notify`.
+
+`-Message` is optional. When omitted, the exact body is `Task completed`. An explicit message is a literal, single-line string of at most 256 UTF-8 bytes. Empty or whitespace-only values, leading/trailing whitespace, CR/LF/NUL, Unicode control characters, U+2028/U+2029, and unpaired surrogates are rejected. The literal is stored in the active request and becomes an external-send authorization when arm succeeds; do not put secrets or sensitive business data in it.
+
+Re-arming an existing `armed` or `attempting` request is idempotent and does not replace its generation or message. An orphaned `attempting` request can be consumed by a later explicit arm and replaced by a new generation.
+
+For a WSL caller, do not pass the message as a Windows process argument. Send an operation envelope through stdin:
+
+```bash
+printf '%s\n' '{"operation":"arm","thread":"codex://threads/<UUID>","message":"Build finished"}' \
+  | pwsh.exe -NoProfile -NonInteractive -File '<windows-skill-path>\\scripts\\windows-helper.ps1'
+```
+
+The helper's result is sanitized and never echoes the message or topic. The
+skill path must be resolved to the Windows checkout; WSL must not write
+`.task-complete-notify` directly. If a WSL process does not inherit the active
+session's `CODEX_HOME`, registration fails rather than selecting another home.
+
+When the Stop-hook canary is not viable, set `TASK_COMPLETE_NOTIFY_WATCHER=1` in the Windows environment before arming. The Windows helper starts the hidden `codex-watcher.ps1` fallback and the watcher owns an OS-lifetime lock, persistent per-thread rollout offsets, and the same Stop/claim path. If the environment variable is not set, the watcher can be started explicitly with:
+
+```powershell
+pwsh.exe -NoProfile -NonInteractive -File "<skill-dir>\scripts\codex-watcher.ps1"
+```
+
+The fallback is detector-only, not a retry worker: it exits after all active requests are consumed and never resends an `attempting` generation.
+
+## Completion and delivery semantics
+
+The hook claims an `armed` generation atomically as `attempting` before making the HTTP request. It holds the same Windows OS-lifetime per-thread lock used by arm until the request reaches a terminal result. The active generation then becomes `success`, `failure`, or `abandoned` and is no longer eligible for a later completion.
+
+Delivery is one-shot best effort: one application-level send attempt per generation, with no retry, no detached worker, and no automatic resend on the next hook. A final HTTP 200-299 is success; non-2xx, timeout, connection/TLS/DNS error, missing topic, and unknown result are terminal failure. A failure may be silent; the hook must not block or alter the Codex turn. Optional diagnostics must use fixed text and must never include message, topic, URI, prompt, response, repository, or log data.
+
+The ntfy server is fixed at `https://ntfy.sh`. `NTFY_TOPIC` is read from the process environment only at send time; this skill neither sets nor persists it. The production sender puts the notification text in the ntfy message body and omits the title header, because the message body is the only display contract.
+
+## Hook canary
+
+Before enabling the hook, verify with a captured non-production hook input that:
+
+1. `session_id` and `turn_id` are available, the active session's `CODEX_HOME` is inherited, and the transcript's first `session_meta` record matches the session, has `thread_source: "user"`, and has no parent thread.
+2. `SubagentStop` is not used and `stop_hook_active` does not cause an early or duplicate send.
+3. The hook process can read/write `$CODEX_HOME\.task-complete-notify`, acquire the Windows lock, and inherit `NTFY_TOPIC`.
+4. Existing Stop hooks do not request continuation that would make this hook an early-stop detector.
+5. A mocked or controlled ntfy result exercises 2xx, non-2xx, timeout, connection error, and result-unknown paths; every path consumes the generation and later Stop input does not resend.
+
+If the Stop hook cannot satisfy these checks, use the JSONL watcher fallback with persistent cursors, periodic rescan, complete-line parsing, and the same pre-send claim and one-shot state semantics. The watcher validates `session_meta` before scanning a rollout, treats `FileSystemWatcher`-style wakeups as optional (the shipped fallback uses periodic rescan), and closes its lifetime lock while holding the coordination lock before exit so a concurrent arm can start a replacement watcher without a lost wake-up.
+
+## Diagnostic scripts
+
+The display-comparison scripts under `scripts/diagnostics/` are manual
+diagnostics only. They send intentionally random test values to the configured
+topic and are never invoked by the arm, Stop-hook, notifier, or watcher paths.
+Run them only when an explicit device-display check is wanted; they require the
+process `NTFY_TOPIC` and perform a real ntfy publish.
+
+## Privacy and state
+
+State files are under the resolved `$CODEX_HOME\.task-complete-notify`, outside
+the skill checkout. Active requests may contain the explicit message; lock,
+attempting, and terminal records must not. Do not put `NTFY_TOPIC`, server
+credentials, prompt/response text, thread titles, repository paths, raw arm
+input, or ntfy response bodies in state, stdout, stderr, or hook output. The
+public Windows arm command accepts `-Message`, so its caller's command line
+may contain that value; use the WSL stdin envelope when it must not appear in a
+command line. WSL requests and all internal helper/notifier/watcher child
+invocations carry the message through stdin and never through child-process
+arguments.
+
+The design rationale, rejected alternatives, evidence links, and maintenance
+invariants are recorded in [`references/design.md`](references/design.md).
+
+See `references/codex-hooks.json` for a minimal Stop-hook configuration example. The example is documentation only; this skill does not edit the user's Codex configuration automatically.

--- a/.agents/skills/task-complete-notify/SKILL.md
+++ b/.agents/skills/task-complete-notify/SKILL.md
@@ -73,6 +73,10 @@ skill path must be resolved to the Windows checkout; WSL must not write
 `.task-complete-notify` directly. If a WSL process does not inherit the active
 session's `CODEX_HOME`, registration fails rather than selecting another home.
 
+All stdin boundaries use an explicit UTF-8 `StreamReader` over the standard
+input stream. The scripts do not mutate global console encoding and do not
+require an attached console.
+
 When the Stop-hook canary is not viable, set `TASK_COMPLETE_NOTIFY_WATCHER=1` in the Windows environment before arming. The Windows helper starts the hidden `codex-watcher.ps1` fallback and the watcher owns an OS-lifetime lock, persistent per-thread rollout offsets, and the same Stop/claim path. If the environment variable is not set, the watcher can be started explicitly with:
 
 ```powershell
@@ -85,7 +89,7 @@ The fallback is detector-only, not a retry worker: it exits after all active req
 
 The hook claims an `armed` generation atomically as `attempting` before making the HTTP request. It holds the same Windows OS-lifetime per-thread lock used by arm until the request reaches a terminal result. The active generation then becomes `success`, `failure`, or `abandoned` and is no longer eligible for a later completion.
 
-Delivery is one-shot best effort: one application-level send attempt per generation, with no retry, no detached worker, and no automatic resend on the next hook. A final HTTP 200-299 is success; non-2xx, timeout, connection/TLS/DNS error, missing topic, and unknown result are terminal failure. A failure may be silent; the hook must not block or alter the Codex turn. Optional diagnostics must use fixed text and must never include message, topic, URI, prompt, response, repository, or log data.
+Delivery is one-shot best effort: one application-level send attempt per generation, with no retry, no detached worker, and no automatic resend on the next hook. A final HTTP 200-299 is success; non-2xx, timeout, connection/TLS/DNS error, missing topic, and unknown result are terminal failure. A failure may be silent and the hook never changes the Codex turn result. The Stop hook is synchronous by design: an armed event may wait up to 55 seconds for the helper. The helper allows up to 10 seconds for the per-thread lock and 35 seconds for the notifier child; the notifier requests a 10-second connection timeout and a 20-second operation inactivity timeout, so the wrapper retains a small cleanup margin. The hook configuration keeps a 90-second ceiling. Unarmed or rejected events return without a notification attempt. Optional diagnostics must use fixed text and must never include message, topic, URI, prompt, response, repository, or log data.
 
 The ntfy server is fixed at `https://ntfy.sh`. `NTFY_TOPIC` is read from the process environment only at send time; this skill neither sets nor persists it. The production sender puts the notification text in the ntfy message body and omits the title header, because the message body is the only display contract.
 

--- a/.agents/skills/task-complete-notify/agents/openai.yaml
+++ b/.agents/skills/task-complete-notify/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Task-complete notification"
+  short_description: "Arm a one-shot completion notification"
+  default_prompt: "Use $task-complete-notify only after the user explicitly asks to arm a completion notification."

--- a/.agents/skills/task-complete-notify/references/codex-hooks.json
+++ b/.agents/skills/task-complete-notify/references/codex-hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pwsh.exe -NoProfile -NonInteractive -File C:/path/to/task-complete-notify/scripts/codex-stop-hook.ps1",
+            "timeout": 90
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.agents/skills/task-complete-notify/references/design.md
+++ b/.agents/skills/task-complete-notify/references/design.md
@@ -1,0 +1,71 @@
+# Task-complete notification: design record
+
+この文書は、`task-complete-notify` の現在の契約と、採用理由を対応付けるための設計記録です。
+利用手順と実行時の安全境界は、親文書の [`SKILL.md`](../SKILL.md) を正本とします。
+
+## 現在の不変条件
+
+- arm の入力からは、standalone なUUID候補を正規化し、異なる候補が1件だけのときだけ対象を確定する。同じUUIDの繰り返しは許可する。
+- canonical URIは `codex://threads/<UUID>`。legacy形式、余分なpath/query/fragmentは拒否する。
+- relaxedなUUID抽出は外部arm入力だけに適用し、hook・transcript metadata・state・watcherの内部値はstrict parserで完全一致検証する。
+- arm前に、現在のプロセスが選択しているCodex homeの `session_index.jsonl` と、同homeのactive rollout先頭 `session_meta` を照合する。`id == session_id == target`、`thread_source == user`、親なしを満たさなければstateを作らない。
+- runtime stateは実行時に解決した `$CODEX_HOME\.task-complete-notify` に置く。`CODEX_HOME`未設定時だけユーザープロファイルの`.codex`を使う。
+- Stop hookを第一検出器、JSONL watcherを明示的なfallbackとし、両方を独立senderとして有効化しない。
+- 1 generationにつき送信APIを1回だけ試行し、結果はterminal stateへ消費する。retryや自動再送は行わない。
+- state、stdout/stderr、hook outputにはtopic、秘密、raw arm input、prompt/response、thread title、repository pathを保存・出力しない。
+- hookやwatcherを有効化する前に、対象セッションで実際に選択されるpermission profileとsandboxの組み合わせをcanaryで確認する。必要な権限は同homeのsession index/transcript読取、同home state rootへの限定書込、`ntfy.sh`へのHTTPS通信に絞り、skillはCodex設定を自動変更しない。
+
+## 判断理由
+
+### UUIDを最初の一致で採用しない
+
+Codexのログ、Markdown、引用文には複数のUUIDが混在し得ます。最初の一致やcanonical URI優先では、別threadを黙って選択する危険があります。そのため、同じUUIDの反復だけを重複排除し、異なるUUIDが複数あれば `thread_ambiguous` として停止します。
+
+UUIDにASCII英数字・underscore・hyphenが直結した部分一致も候補にしません。入力全体が大きくなり過ぎないようarm入力はUTF-8 4 KiBに制限し、抽出元の全文は保持しません。
+
+### strict parserとarm extractorを分離する
+
+hookやstateの値まで部分一致にすると、壊れたmetadataや改変されたstateから別のUUIDを拾う可能性があります。したがって、外部入力には `Extract-ArmThreadId`、内部境界には厳格な `Normalize-CodexThreadId` を使い分けます。
+
+### stateをCodex home単位に分ける
+
+skill checkout内の共有stateでは、`.codex`と`.codex-personal`を同時に使ったときにrequest、watcher lock、checkpointが衝突します。Codexが実際に使っているhomeからstateとsessions rootを同時に導出すれば、homeごとの常駐watcherを独立させられます。
+
+stateディレクトリはインストール時には作らず、対象が現在のhomeで管理されていることを確認したarm後にだけ作ります。未知のhomeや未知のUUIDを試しただけで新しいruntime directoryを増やさないためです。
+
+`CODEX_HOME`はプロセス環境からのみ選びます。別homeを入力値から推測したり、WSL envelopeで任意homeを上書きしたりしません。WSL側が現在のセッション環境を継承できない場合は、誤ったhomeへの登録を避けるため失敗させます。
+
+### indexとtranscriptを二重に確認する
+
+`session_index.jsonl`は同じhomeの候補を高速に絞るために使いますが、indexだけではrolloutの正当性を確認できません。最終判定はactive rolloutの先頭 `session_meta` とし、root user sessionであることを確認します。filename一致だけの判定や、archived rolloutの受理は行いません。
+
+### `references/design.md`をREADMEの代わりに使う
+
+`SKILL.md`は呼び出し方と現行契約に集中させ、採用理由・却下案・証拠・保守条件はこの設計記録に分離します。READMEを別に複製すると利用手順と契約が陳腐化しやすいためです。
+
+このファイルにはローカル絶対path、ユーザー名、実UUID、thread名、prompt/transcript内容、topic、credential、private configの値を記録しません。Issueはprovenance linkとして参照しますが、Issueが読めなくても現行判断が理解できるよう要約を自足させます。
+
+### 診断スクリプトを本番経路から分離する
+
+端末表示の比較用スクリプトは、実ntfy publishを行うため本番のadapter・hook・watcherから分離し、`scripts/diagnostics/`に置きます。これらは受入経路から自動起動せず、明示的な表示確認でだけ実行します。ランダム値以外のmessage、topic、prompt、responseは扱いません。
+
+## 検証と保守
+
+仕様を変更するときは、次を同じ変更として扱います。
+
+1. `SKILL.md`の現行契約
+2. `scripts/`のadapter・検出器・sender、および`scripts/diagnostics/`の診断資材
+3. `tests/task-complete-notify.tests.ps1`の受入条件
+4. この設計記録の不変条件・判断理由
+5. GitHub Issue #3の本文と判断履歴コメント
+
+最低限、入力抽出の曖昧性、wrong-home拒否とstate未作成、homeごとのlock分離、Stop/watcherの一回性、秘密値非漏洩を再検証します。
+
+## 根拠リンク
+
+- [GitHub Issue #3: notification-skill](https://github.com/the9ball/.dotfiles/issues/3)
+- [Issue #3 initial process-reuse draft](https://github.com/the9ball/.dotfiles/issues/3#issuecomment-5628328226)
+- [Issue #3 final contract discussion](https://github.com/the9ball/.dotfiles/issues/3#issuecomment-5629234932)
+- [Issue #3 implementation and verification record](https://github.com/the9ball/.dotfiles/issues/3#issuecomment-5630098951)
+- [Issue #3 review-response policy](https://github.com/the9ball/.dotfiles/issues/3#issuecomment-5632941893)
+- [Issue #3 live-canary result](https://github.com/the9ball/.dotfiles/issues/3#issuecomment-5633214614)

--- a/.agents/skills/task-complete-notify/references/design.md
+++ b/.agents/skills/task-complete-notify/references/design.md
@@ -11,6 +11,8 @@
 - arm前に、現在のプロセスが選択しているCodex homeの `session_index.jsonl` と、同homeのactive rollout先頭 `session_meta` を照合する。`id == session_id == target`、`thread_source == user`、親なしを満たさなければstateを作らない。
 - runtime stateは実行時に解決した `$CODEX_HOME\.task-complete-notify` に置く。`CODEX_HOME`未設定時だけユーザープロファイルの`.codex`を使う。
 - Stop hookを第一検出器、JSONL watcherを明示的なfallbackとし、両方を独立senderとして有効化しない。
+- Stop hookは同期呼出しだが、thread lock 10秒＋notifier child 35秒＋後処理マージン5秒＜helper wrapper 55秒＜hook設定上限90秒の階層に固定する。notifierのHTTP設定はconnect timeout 10秒とoperation inactivity timeout 20秒であり、HTTP全体の上限とは扱わない。失敗してもturn結果は変更せず、非同期workerは導入しない。
+- stdinは各境界で標準入力ストリームを明示的なUTF-8 `StreamReader`として読み、`Console.InputEncoding`の変更やコンソール接続を前提にしない。
 - 1 generationにつき送信APIを1回だけ試行し、結果はterminal stateへ消費する。retryや自動再送は行わない。
 - state、stdout/stderr、hook outputにはtopic、秘密、raw arm input、prompt/response、thread title、repository pathを保存・出力しない。
 - hookやwatcherを有効化する前に、対象セッションで実際に選択されるpermission profileとsandboxの組み合わせをcanaryで確認する。必要な権限は同homeのsession index/transcript読取、同home state rootへの限定書込、`ntfy.sh`へのHTTPS通信に絞り、skillはCodex設定を自動変更しない。

--- a/.agents/skills/task-complete-notify/scripts/arm-notification.ps1
+++ b/.agents/skills/task-complete-notify/scripts/arm-notification.ps1
@@ -13,7 +13,6 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
-[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
 $ScriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 function Invoke-WindowsHelper {

--- a/.agents/skills/task-complete-notify/scripts/arm-notification.ps1
+++ b/.agents/skills/task-complete-notify/scripts/arm-notification.ps1
@@ -1,0 +1,159 @@
+#requires -Version 7.4
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [string]$Thread,
+
+    [Parameter()]
+    [AllowEmptyString()]
+    [string]$Message
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
+$ScriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+function Invoke-WindowsHelper {
+    <#
+    .SYNOPSIS
+    Sends one sanitized arm request to the Windows helper through standard input.
+
+    .PARAMETER RequestJson
+    The JSON envelope containing the target and optional literal message.
+
+    .OUTPUTS
+    System.String. Returns the helper's sanitized JSON result, or an empty string
+    when the helper could not be started or returned unusable output.
+
+    .NOTES
+    The message is deliberately excluded from the child command line and from
+    all diagnostics produced by this wrapper.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$RequestJson
+    )
+
+    $HelperPath = Join-Path $ScriptDirectory 'windows-helper.ps1'
+    $PowerShellExecutable = Join-Path $PSHOME 'pwsh.exe'
+
+    if (-not (Test-Path -LiteralPath $HelperPath -PathType Leaf) -or
+        -not (Test-Path -LiteralPath $PowerShellExecutable -PathType Leaf)) {
+        return ''
+    }
+
+    $Process = $null
+    try {
+        $StartInfo = [Diagnostics.ProcessStartInfo]::new()
+        $StartInfo.FileName = $PowerShellExecutable
+        $StartInfo.UseShellExecute = $false
+        $StartInfo.CreateNoWindow = $true
+        $StartInfo.RedirectStandardInput = $true
+        $StartInfo.RedirectStandardOutput = $true
+        $StartInfo.RedirectStandardError = $true
+        $StartInfo.StandardInputEncoding = [Text.UTF8Encoding]::new($false)
+        $StartInfo.StandardOutputEncoding = [Text.UTF8Encoding]::new($false)
+        $StartInfo.StandardErrorEncoding = [Text.UTF8Encoding]::new($false)
+        [void]$StartInfo.ArgumentList.Add('-NoProfile')
+        [void]$StartInfo.ArgumentList.Add('-NonInteractive')
+        [void]$StartInfo.ArgumentList.Add('-File')
+        [void]$StartInfo.ArgumentList.Add($HelperPath)
+
+        $Process = [Diagnostics.Process]::new()
+        $Process.StartInfo = $StartInfo
+        if (-not $Process.Start()) {
+            return ''
+        }
+
+        $OutputTask = $Process.StandardOutput.ReadToEndAsync()
+        $ErrorTask = $Process.StandardError.ReadToEndAsync()
+        $Process.StandardInput.Write($RequestJson)
+        $Process.StandardInput.Close()
+        if (-not $Process.WaitForExit(60000)) {
+            try {
+                $Process.Kill($true)
+            }
+            catch {
+                # The process is already terminating; keep the fixed failure.
+            }
+            return ''
+        }
+
+        $HelperOutput = $OutputTask.GetAwaiter().GetResult()
+        [void]$ErrorTask.GetAwaiter().GetResult()
+        if ($Process.ExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($HelperOutput)) {
+            return ''
+        }
+
+        $SanitizedResult = $HelperOutput | ConvertFrom-Json
+        return ($SanitizedResult | ConvertTo-Json -Compress)
+    }
+    catch {
+        return ''
+    }
+    finally {
+        if ($null -ne $Process) {
+            $Process.Dispose()
+        }
+    }
+}
+
+function Write-ArmResult {
+    <#
+    .SYNOPSIS
+    Emits a fixed-field arm result without exposing notification content.
+
+    .PARAMETER ResultJson
+    Sanitized JSON returned by the helper.
+
+    .OUTPUTS
+    None. A compact JSON result is written to standard output.
+    #>
+    param(
+        [AllowEmptyString()]
+        [string]$ResultJson
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ResultJson)) {
+        [Console]::Out.WriteLine('{"Ok":false,"Status":"helper_failure"}')
+        return
+    }
+
+    try {
+        $Result = $ResultJson | ConvertFrom-Json
+        $Output = [ordered]@{
+            Ok = [bool]$Result.Ok
+            Status = [string]$Result.Status
+        }
+        [Console]::Out.WriteLine(($Output | ConvertTo-Json -Compress))
+    }
+    catch {
+        [Console]::Out.WriteLine('{"Ok":false,"Status":"helper_failure"}')
+    }
+}
+
+$Envelope = [ordered]@{
+    operation = 'arm'
+    thread = $Thread
+}
+if ($PSBoundParameters.ContainsKey('Message')) {
+    $Envelope.message = $Message
+}
+
+$ResultJson = Invoke-WindowsHelper -RequestJson ($Envelope | ConvertTo-Json -Compress)
+Write-ArmResult -ResultJson $ResultJson
+
+try {
+    $ResultObject = $ResultJson | ConvertFrom-Json
+    if ($ResultObject.Ok -ne $true) {
+        exit 1
+    }
+}
+catch {
+    exit 1
+}
+
+exit 0

--- a/.agents/skills/task-complete-notify/scripts/codex-stop-hook.ps1
+++ b/.agents/skills/task-complete-notify/scripts/codex-stop-hook.ps1
@@ -1,0 +1,154 @@
+#requires -Version 7.4
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
+$ScriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+function Get-JsonProperty {
+    <#
+    .SYNOPSIS
+    Reads one optional property from a JSON-derived object.
+
+    .PARAMETER InputObject
+    The parsed hook object.
+
+    .PARAMETER Name
+    The exact property name to read.
+
+    .OUTPUTS
+    System.Object. Returns the property value or null when absent.
+    #>
+    param(
+        [AllowNull()]
+        [object]$InputObject,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    $Property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $Property) {
+        return $null
+    }
+
+    return $Property.Value
+}
+
+function Invoke-WindowsHelper {
+    <#
+    .SYNOPSIS
+    Sends a minimal Stop envelope to the Windows state helper via stdin.
+
+    .PARAMETER RequestJson
+    The JSON envelope containing only safe hook identity fields.
+
+    .OUTPUTS
+    None. Helper output and errors are intentionally discarded so the hook
+    cannot echo a message, topic, transcript content, or response body.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$RequestJson
+    )
+
+    $HelperPath = Join-Path $ScriptDirectory 'windows-helper.ps1'
+    $PowerShellExecutable = Join-Path $PSHOME 'pwsh.exe'
+
+    if (-not (Test-Path -LiteralPath $HelperPath -PathType Leaf) -or
+        -not (Test-Path -LiteralPath $PowerShellExecutable -PathType Leaf)) {
+        return
+    }
+
+    $Process = $null
+    try {
+        $StartInfo = [Diagnostics.ProcessStartInfo]::new()
+        $StartInfo.FileName = $PowerShellExecutable
+        $StartInfo.UseShellExecute = $false
+        $StartInfo.CreateNoWindow = $true
+        $StartInfo.RedirectStandardInput = $true
+        $StartInfo.RedirectStandardOutput = $true
+        $StartInfo.RedirectStandardError = $true
+        $StartInfo.StandardInputEncoding = [Text.UTF8Encoding]::new($false)
+        $StartInfo.StandardOutputEncoding = [Text.UTF8Encoding]::new($false)
+        $StartInfo.StandardErrorEncoding = [Text.UTF8Encoding]::new($false)
+        [void]$StartInfo.ArgumentList.Add('-NoProfile')
+        [void]$StartInfo.ArgumentList.Add('-NonInteractive')
+        [void]$StartInfo.ArgumentList.Add('-File')
+        [void]$StartInfo.ArgumentList.Add($HelperPath)
+
+        $Process = [Diagnostics.Process]::new()
+        $Process.StartInfo = $StartInfo
+        if (-not $Process.Start()) {
+            return
+        }
+
+        $OutputTask = $Process.StandardOutput.ReadToEndAsync()
+        $ErrorTask = $Process.StandardError.ReadToEndAsync()
+        $Process.StandardInput.Write($RequestJson)
+        $Process.StandardInput.Close()
+        if (-not $Process.WaitForExit(60000)) {
+            try {
+                $Process.Kill($true)
+            }
+            catch {
+                # The process is already terminating; keep the best-effort hook.
+            }
+            return
+        }
+
+        [void]$OutputTask.GetAwaiter().GetResult()
+        [void]$ErrorTask.GetAwaiter().GetResult()
+    }
+    catch {
+        # Stop hooks are best effort; a failed helper must not alter the turn.
+    }
+    finally {
+        if ($null -ne $Process) {
+            $Process.Dispose()
+        }
+    }
+}
+
+$HookInput = $null
+try {
+    $HookText = [Console]::In.ReadToEnd()
+    if ([string]::IsNullOrWhiteSpace($HookText)) {
+        exit 0
+    }
+
+    $HookInput = $HookText | ConvertFrom-Json
+}
+catch {
+    exit 0
+}
+
+$StopHookActive = Get-JsonProperty -InputObject $HookInput -Name 'stop_hook_active'
+$StopHookActiveIsBoolean = $StopHookActive -is [bool]
+if (-not $StopHookActiveIsBoolean) {
+    exit 0
+}
+
+$SafeHook = [ordered]@{
+    hook_event_name = Get-JsonProperty -InputObject $HookInput -Name 'hook_event_name'
+    session_id = Get-JsonProperty -InputObject $HookInput -Name 'session_id'
+    transcript_path = Get-JsonProperty -InputObject $HookInput -Name 'transcript_path'
+    turn_id = Get-JsonProperty -InputObject $HookInput -Name 'turn_id'
+    stop_hook_active = $StopHookActive
+}
+
+$Envelope = [ordered]@{
+    operation = 'stop'
+    hook = $SafeHook
+}
+
+Invoke-WindowsHelper -RequestJson ($Envelope | ConvertTo-Json -Compress)
+exit 0

--- a/.agents/skills/task-complete-notify/scripts/codex-stop-hook.ps1
+++ b/.agents/skills/task-complete-notify/scripts/codex-stop-hook.ps1
@@ -6,8 +6,8 @@ param()
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
-[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
 $ScriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$HelperTimeoutMilliseconds = 55000
 
 function Get-JsonProperty {
     <#
@@ -95,7 +95,7 @@ function Invoke-WindowsHelper {
         $ErrorTask = $Process.StandardError.ReadToEndAsync()
         $Process.StandardInput.Write($RequestJson)
         $Process.StandardInput.Close()
-        if (-not $Process.WaitForExit(60000)) {
+        if (-not $Process.WaitForExit($HelperTimeoutMilliseconds)) {
             try {
                 $Process.Kill($true)
             }
@@ -119,8 +119,16 @@ function Invoke-WindowsHelper {
 }
 
 $HookInput = $null
+$InputStream = $null
+$InputReader = $null
 try {
-    $HookText = [Console]::In.ReadToEnd()
+    $InputStream = [Console]::OpenStandardInput()
+    $InputReader = [IO.StreamReader]::new(
+        $InputStream,
+        [Text.UTF8Encoding]::new($false),
+        $true
+    )
+    $HookText = $InputReader.ReadToEnd()
     if ([string]::IsNullOrWhiteSpace($HookText)) {
         exit 0
     }
@@ -129,6 +137,14 @@ try {
 }
 catch {
     exit 0
+}
+finally {
+    if ($null -ne $InputReader) {
+        $InputReader.Dispose()
+    }
+    if ($null -ne $InputStream) {
+        $InputStream.Dispose()
+    }
 }
 
 $StopHookActive = Get-JsonProperty -InputObject $HookInput -Name 'stop_hook_active'

--- a/.agents/skills/task-complete-notify/scripts/codex-watcher.ps1
+++ b/.agents/skills/task-complete-notify/scripts/codex-watcher.ps1
@@ -1,0 +1,1246 @@
+#requires -Version 7.4
+
+[CmdletBinding()]
+param(
+    [ValidateRange(100, 60000)]
+    [int]$PollIntervalMilliseconds = 2000,
+
+    [switch]$Once,
+
+    [string]$HelperScriptPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
+
+$ScriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillDirectory = Split-Path -Parent $ScriptDirectory
+
+function Resolve-CodexHome {
+    <#
+    .SYNOPSIS
+    Resolves the Codex home used by this watcher process.
+
+    .OUTPUTS
+    System.String. Returns an absolute Codex home path, or null when the
+    configured path cannot be resolved.
+
+    .NOTES
+    The watcher inherits the active session's process environment and never
+    selects a home from a target UUID or from another provider.
+    #>
+    $ConfiguredHome = [Environment]::GetEnvironmentVariable('CODEX_HOME', 'Process')
+    if ([string]::IsNullOrWhiteSpace($ConfiguredHome)) {
+        $UserProfile = [Environment]::GetFolderPath('UserProfile')
+        if ([string]::IsNullOrWhiteSpace($UserProfile)) {
+            return $null
+        }
+
+        $ConfiguredHome = Join-Path $UserProfile '.codex'
+    }
+
+    try {
+        $ResolvedHome = [IO.Path]::GetFullPath($ConfiguredHome)
+    }
+    catch {
+        return $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($ResolvedHome)) {
+        return $null
+    }
+
+    return $ResolvedHome
+}
+
+$CodexHome = Resolve-CodexHome
+$StateDirectory = if ([string]::IsNullOrWhiteSpace($CodexHome)) {
+    Join-Path $SkillDirectory '.task-complete-notify.invalid'
+}
+else {
+    Join-Path $CodexHome '.task-complete-notify'
+}
+$RequestDirectory = Join-Path $StateDirectory 'requests'
+$LockDirectory = Join-Path $StateDirectory 'locks'
+$CheckpointDirectory = Join-Path $StateDirectory 'checkpoints'
+$TerminalDirectory = Join-Path $StateDirectory 'terminal'
+$WatcherLockPath = Join-Path $StateDirectory 'watcher.lock'
+$CoordinationLockPath = Join-Path $StateDirectory 'coordination.lock'
+$HelperPath = if ([string]::IsNullOrWhiteSpace($HelperScriptPath)) {
+    Join-Path $ScriptDirectory 'windows-helper.ps1'
+}
+else {
+    [IO.Path]::GetFullPath($HelperScriptPath)
+}
+
+function Get-JsonProperty {
+    <#
+    .SYNOPSIS
+    Reads one optional property from a JSON-derived object.
+
+    .PARAMETER InputObject
+    The parsed JSON object.
+
+    .PARAMETER Name
+    The exact property name to read.
+
+    .OUTPUTS
+    System.Object. Returns the property value or null when absent.
+    #>
+    param(
+        [AllowNull()]
+        [object]$InputObject,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    if ($InputObject -is [Collections.IDictionary] -and $InputObject.Contains($Name)) {
+        return $InputObject[$Name]
+    }
+
+    $Property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $Property) {
+        return $null
+    }
+
+    return $Property.Value
+}
+
+function Normalize-CodexThreadId {
+    <#
+    .SYNOPSIS
+    Normalizes a canonical Codex thread URI or raw UUID.
+
+    .PARAMETER InputValue
+    The canonical `codex://threads/<UUID>` value or raw UUID shorthand.
+
+    .OUTPUTS
+    System.String. Returns a lowercase UUID, or null for invalid input.
+    #>
+    param(
+        [AllowNull()]
+        [object]$InputValue
+    )
+
+    $TextValue = if ($null -eq $InputValue) { '' } else { [string]$InputValue }
+    $UuidText = $null
+    if ($TextValue -match '^codex://threads/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$') {
+        $UuidText = $Matches[1]
+    }
+    elseif ($TextValue -match '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$') {
+        $UuidText = $Matches[1]
+    }
+    else {
+        return $null
+    }
+
+    $GuidValue = [Guid]::Empty
+    if (-not [Guid]::TryParse($UuidText, [ref]$GuidValue)) {
+        return $null
+    }
+
+    return $GuidValue.ToString('D').ToLowerInvariant()
+}
+
+function Get-CodexSessionsDirectory {
+    <#
+    .SYNOPSIS
+    Returns the sessions directory under the watcher home.
+
+    .OUTPUTS
+    System.String. Returns the resolved sessions path, or null for an invalid
+    home.
+    #>
+    if ([string]::IsNullOrWhiteSpace($CodexHome)) {
+        return $null
+    }
+
+    return (Join-Path $CodexHome 'sessions')
+}
+
+function Initialize-WatcherDirectories {
+    <#
+    .SYNOPSIS
+    Creates the runtime state directories under the resolved Codex home.
+
+    .OUTPUTS
+    None. Directory creation is a local side effect.
+    #>
+    if ([string]::IsNullOrWhiteSpace($CodexHome) -or
+        -not (Test-Path -LiteralPath $CodexHome -PathType Container)) {
+        throw 'codex_home_invalid'
+    }
+
+    foreach ($DirectoryPath in @($StateDirectory, $RequestDirectory, $LockDirectory, $CheckpointDirectory, $TerminalDirectory)) {
+        New-Item -ItemType Directory -Force -Path $DirectoryPath | Out-Null
+    }
+}
+
+function Acquire-WatcherLock {
+    <#
+    .SYNOPSIS
+    Acquires the watcher process lifetime lock.
+
+    .OUTPUTS
+    System.IO.FileStream. Returns an exclusive stream, or null when another
+    watcher already owns it.
+
+    .NOTES
+    The open stream is the ownership proof; marker-file existence alone is not.
+    #>
+    try {
+        return [IO.File]::Open(
+            $WatcherLockPath,
+            [IO.FileMode]::OpenOrCreate,
+            [IO.FileAccess]::ReadWrite,
+            [IO.FileShare]::None
+        )
+    }
+    catch [IO.IOException] {
+        return $null
+    }
+    catch {
+        return $null
+    }
+}
+
+function Acquire-CoordinationLock {
+    <#
+    .SYNOPSIS
+    Acquires the short-lived lock shared with arm operations.
+
+    .PARAMETER TimeoutMilliseconds
+    Maximum time to wait for the lock.
+
+    .OUTPUTS
+    System.IO.FileStream. Returns an exclusive stream, or null on timeout.
+    #>
+    param(
+        [ValidateRange(0, 120000)]
+        [int]$TimeoutMilliseconds = 10000
+    )
+
+    $Stopwatch = [Diagnostics.Stopwatch]::StartNew()
+    while ($Stopwatch.ElapsedMilliseconds -le $TimeoutMilliseconds) {
+        try {
+            return [IO.File]::Open(
+                $CoordinationLockPath,
+                [IO.FileMode]::OpenOrCreate,
+                [IO.FileAccess]::ReadWrite,
+                [IO.FileShare]::None
+            )
+        }
+        catch [IO.IOException] {
+            Start-Sleep -Milliseconds 50
+        }
+        catch {
+            return $null
+        }
+    }
+
+    return $null
+}
+
+function Get-ThreadLockPath {
+    <#
+    .SYNOPSIS
+    Builds the per-thread lock path for checkpoint publication.
+
+    .PARAMETER ThreadId
+    A normalized lowercase UUID.
+
+    .OUTPUTS
+    System.String. Returns the lock path.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId
+    )
+
+    return (Join-Path $LockDirectory "$ThreadId.lock")
+}
+
+function Acquire-ThreadLock {
+    <#
+    .SYNOPSIS
+    Acquires a short-lived exclusive lock for one checkpoint update.
+
+    .PARAMETER ThreadId
+    A normalized lowercase UUID.
+
+    .PARAMETER TimeoutMilliseconds
+    Maximum time to wait for the lock.
+
+    .OUTPUTS
+    System.IO.FileStream. Returns an exclusive stream or null on timeout.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId,
+
+        [ValidateRange(0, 120000)]
+        [int]$TimeoutMilliseconds = 10000
+    )
+
+    $LockPath = Get-ThreadLockPath -ThreadId $ThreadId
+    $Stopwatch = [Diagnostics.Stopwatch]::StartNew()
+    while ($Stopwatch.ElapsedMilliseconds -le $TimeoutMilliseconds) {
+        try {
+            return [IO.File]::Open(
+                $LockPath,
+                [IO.FileMode]::OpenOrCreate,
+                [IO.FileAccess]::ReadWrite,
+                [IO.FileShare]::None
+            )
+        }
+        catch [IO.IOException] {
+            Start-Sleep -Milliseconds 50
+        }
+        catch {
+            return $null
+        }
+    }
+
+    return $null
+}
+
+function Read-JsonDocument {
+    <#
+    .SYNOPSIS
+    Reads one local JSON document without emitting its contents.
+
+    .PARAMETER Path
+    The JSON path to read.
+
+    .OUTPUTS
+    System.Object. Returns the parsed document or null when absent/invalid.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        return (Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json)
+    }
+    catch {
+        return $null
+    }
+}
+
+function Write-AtomicJsonDocument {
+    <#
+    .SYNOPSIS
+    Publishes one checkpoint JSON document atomically.
+
+    .PARAMETER Path
+    The destination JSON path.
+
+    .PARAMETER Document
+    The object to serialize.
+
+    .OUTPUTS
+    None. The destination is replaced atomically on success.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [object]$Document
+    )
+
+    $DirectoryPath = Split-Path -Parent $Path
+    $FileName = Split-Path -Leaf $Path
+    $TemporaryPath = Join-Path $DirectoryPath ".${FileName}.$([Guid]::NewGuid().ToString('N')).tmp"
+    $BackupPath = Join-Path $DirectoryPath ".${FileName}.$([Guid]::NewGuid().ToString('N')).bak"
+    try {
+        $JsonText = $Document | ConvertTo-Json -Depth 20 -Compress
+        [IO.File]::WriteAllText(
+            $TemporaryPath,
+            "$JsonText`n",
+            [Text.UTF8Encoding]::new($false)
+        )
+        if (Test-Path -LiteralPath $Path -PathType Leaf) {
+            [IO.File]::Replace($TemporaryPath, $Path, $BackupPath, $true)
+            Remove-Item -LiteralPath $BackupPath -Force -ErrorAction SilentlyContinue
+        }
+        else {
+            [IO.File]::Move($TemporaryPath, $Path)
+        }
+    }
+    catch {
+        # A later rescan can recover a transient checkpoint write failure.
+    }
+    finally {
+        if (Test-Path -LiteralPath $TemporaryPath -PathType Leaf) {
+            Remove-Item -LiteralPath $TemporaryPath -Force -ErrorAction SilentlyContinue
+        }
+        if (Test-Path -LiteralPath $BackupPath -PathType Leaf) {
+            Remove-Item -LiteralPath $BackupPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Get-ActiveRequests {
+    <#
+    .SYNOPSIS
+    Loads all currently armed Codex request documents.
+
+    .OUTPUTS
+    PSCustomObject[]. Returns sanitized request metadata for local processing.
+    #>
+    $Requests = @()
+    if (-not (Test-Path -LiteralPath $RequestDirectory -PathType Container)) {
+        return $Requests
+    }
+
+    foreach ($RequestFile in Get-ChildItem -LiteralPath $RequestDirectory -Filter '*.json' -File -ErrorAction SilentlyContinue) {
+        $State = Read-JsonDocument -Path $RequestFile.FullName
+        if ($null -eq $State) {
+            continue
+        }
+
+        if ([string](Get-JsonProperty -InputObject $State -Name 'provider') -ne 'codex' -or
+            [string](Get-JsonProperty -InputObject $State -Name 'status') -ne 'armed') {
+            continue
+        }
+
+        $Target = Get-JsonProperty -InputObject $State -Name 'target'
+        $ThreadId = Normalize-CodexThreadId -InputValue (Get-JsonProperty -InputObject $Target -Name 'threadId')
+        if ($null -eq $ThreadId) {
+            continue
+        }
+
+        $Requests += [pscustomobject]@{
+            ThreadId = $ThreadId
+            State = $State
+            RequestPath = $RequestFile.FullName
+            CheckpointPath = Join-Path $CheckpointDirectory "$ThreadId.json"
+        }
+    }
+
+    return $Requests
+}
+
+function Read-Checkpoint {
+    <#
+    .SYNOPSIS
+    Reads one thread's persistent rollout offsets and arm timestamp.
+
+    .PARAMETER Request
+    An active request object from Get-ActiveRequests.
+
+    .OUTPUTS
+    PSCustomObject. Returns thread ID, arm timestamp, and a case-insensitive
+    path-to-offset map.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$Request
+    )
+
+    $Offsets = [Collections.Hashtable]::new([StringComparer]::OrdinalIgnoreCase)
+    $Checkpoint = Read-JsonDocument -Path $Request.CheckpointPath
+    $ArmedAtUtc = [string](Get-JsonProperty -InputObject $Request.State -Name 'armedAtUtc')
+    $Generation = [string](Get-JsonProperty -InputObject $Request.State -Name 'generation')
+
+    if ($null -ne $Checkpoint) {
+        $CheckpointProvider = [string](Get-JsonProperty -InputObject $Checkpoint -Name 'provider')
+        $CheckpointGeneration = [string](Get-JsonProperty -InputObject $Checkpoint -Name 'generation')
+        $CheckpointTarget = Get-JsonProperty -InputObject $Checkpoint -Name 'target'
+        $CheckpointThreadId = Normalize-CodexThreadId -InputValue (Get-JsonProperty -InputObject $CheckpointTarget -Name 'threadId')
+        if ($CheckpointProvider -eq 'codex' -and
+            $CheckpointGeneration -eq $Generation -and
+            $CheckpointThreadId -eq $Request.ThreadId) {
+            $CheckpointArmedAt = [string](Get-JsonProperty -InputObject $Checkpoint -Name 'armedAtUtc')
+            if (-not [string]::IsNullOrWhiteSpace($CheckpointArmedAt)) {
+                $ArmedAtUtc = $CheckpointArmedAt
+            }
+
+            foreach ($FileEntry in @((Get-JsonProperty -InputObject $Checkpoint -Name 'files'))) {
+                $FilePath = [string](Get-JsonProperty -InputObject $FileEntry -Name 'path')
+                $OffsetValue = Get-JsonProperty -InputObject $FileEntry -Name 'offset'
+                $Offset = 0L
+                if ([string]::IsNullOrWhiteSpace($FilePath) -or
+                    $null -eq $OffsetValue -or
+                    -not [long]::TryParse([string]$OffsetValue, [ref]$Offset) -or
+                    $Offset -lt 0) {
+                    continue
+                }
+                $Offsets[$FilePath] = $Offset
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        ThreadId = $Request.ThreadId
+        Generation = $Generation
+        ArmedAtUtc = $ArmedAtUtc
+        Offsets = $Offsets
+    }
+}
+
+function Save-Checkpoint {
+    <#
+    .SYNOPSIS
+    Persists the current rollout offsets for one active request.
+
+    .PARAMETER Request
+    The active request metadata.
+
+    .PARAMETER Checkpoint
+    The checkpoint object returned by Read-Checkpoint.
+
+    .OUTPUTS
+    None. The checkpoint is atomically written to the resolved home state directory.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$Request,
+
+        [Parameter(Mandatory)]
+        [object]$Checkpoint
+    )
+
+    $ThreadLockStream = $null
+    try {
+        $ThreadLockStream = Acquire-ThreadLock -ThreadId $Request.ThreadId
+        if ($null -eq $ThreadLockStream) {
+            return
+        }
+
+        $CurrentState = Read-JsonDocument -Path $Request.RequestPath
+        if ($null -eq $CurrentState) {
+            return
+        }
+
+        $CurrentProvider = [string](Get-JsonProperty -InputObject $CurrentState -Name 'provider')
+        $CurrentStatus = [string](Get-JsonProperty -InputObject $CurrentState -Name 'status')
+        $CurrentTarget = Get-JsonProperty -InputObject $CurrentState -Name 'target'
+        $CurrentThreadId = Normalize-CodexThreadId -InputValue (Get-JsonProperty -InputObject $CurrentTarget -Name 'threadId')
+        $CurrentGeneration = [string](Get-JsonProperty -InputObject $CurrentState -Name 'generation')
+        if ($CurrentProvider -ne 'codex' -or
+            $CurrentStatus -ne 'armed' -or
+            $CurrentThreadId -ne $Request.ThreadId -or
+            $CurrentGeneration -ne $Checkpoint.Generation) {
+            return
+        }
+
+        $Entries = @(
+            foreach ($Key in $Checkpoint.Offsets.Keys) {
+                [ordered]@{
+                    path = [string]$Key
+                    offset = [long]$Checkpoint.Offsets[$Key]
+                }
+            }
+        )
+        $Document = [ordered]@{
+            schemaVersion = 1
+            provider = 'codex'
+            generation = $Checkpoint.Generation
+            target = [ordered]@{
+                threadId = $Request.ThreadId
+            }
+            armedAtUtc = $Checkpoint.ArmedAtUtc
+            files = $Entries
+        }
+        Write-AtomicJsonDocument -Path $Request.CheckpointPath -Document $Document
+    }
+    catch {
+        # A concurrent arm/claim or transient state failure is retried by the
+        # next scan; stale checkpoint data is never republished.
+    }
+    finally {
+        if ($null -ne $ThreadLockStream) {
+            $ThreadLockStream.Dispose()
+        }
+    }
+}
+
+function Read-FirstLine {
+    <#
+    .SYNOPSIS
+    Reads only the first UTF-8 line of a rollout file.
+
+    .PARAMETER Path
+    The rollout path.
+
+    .OUTPUTS
+    System.String. Returns the first line or null when unavailable.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $Stream = $null
+    $Reader = $null
+    try {
+        $Stream = [IO.File]::Open($Path, [IO.FileMode]::Open, [IO.FileAccess]::Read, [IO.FileShare]::ReadWrite)
+        $Reader = [IO.StreamReader]::new($Stream, [Text.UTF8Encoding]::new($false, $false), $true, 4096, $true)
+        return $Reader.ReadLine()
+    }
+    catch {
+        return $null
+    }
+    finally {
+        if ($null -ne $Reader) {
+            $Reader.Dispose()
+        }
+        if ($null -ne $Stream) {
+            $Stream.Dispose()
+        }
+    }
+}
+
+function Get-UserSessionId {
+    <#
+    .SYNOPSIS
+    Validates rollout session metadata and returns its user session UUID.
+
+    .PARAMETER Path
+    The rollout file whose first record is inspected.
+
+    .OUTPUTS
+    System.String. Returns the normalized user session ID, or null when the
+    rollout is a subagent/guardian, malformed, or not yet fully written.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $FirstLine = Read-FirstLine -Path $Path
+    if ([string]::IsNullOrWhiteSpace($FirstLine)) {
+        return $null
+    }
+
+    try {
+        $Record = $FirstLine | ConvertFrom-Json
+    }
+    catch {
+        return $null
+    }
+
+    if ([string](Get-JsonProperty -InputObject $Record -Name 'type') -ne 'session_meta') {
+        return $null
+    }
+
+    $Payload = Get-JsonProperty -InputObject $Record -Name 'payload'
+    if ($null -eq $Payload) {
+        return $null
+    }
+    $SessionId = Normalize-CodexThreadId -InputValue (Get-JsonProperty -InputObject $Payload -Name 'session_id')
+    $RecordId = Normalize-CodexThreadId -InputValue (Get-JsonProperty -InputObject $Payload -Name 'id')
+    if ($null -eq $SessionId -or $SessionId -ne $RecordId) {
+        return $null
+    }
+
+    if ([string](Get-JsonProperty -InputObject $Payload -Name 'thread_source') -ne 'user') {
+        return $null
+    }
+
+    foreach ($Property in $Payload.PSObject.Properties) {
+        if ($Property.Name -match '^parent' -and -not [string]::IsNullOrWhiteSpace([string]$Property.Value)) {
+            return $null
+        }
+    }
+
+    return $SessionId
+}
+
+function Read-CompleteJsonLines {
+    <#
+    .SYNOPSIS
+    Reads only newline-terminated JSONL records from a byte offset.
+
+    .PARAMETER Path
+    The rollout file to read.
+
+    .PARAMETER StartOffset
+    The byte offset immediately after the last confirmed complete line.
+
+    .OUTPUTS
+    PSCustomObject[]. Each item contains the parsed record (or null for a
+    malformed complete line) and the next safe byte offset.
+
+    .NOTES
+    A partial final line is retained by leaving the checkpoint at its prior
+    offset. UTF-8 decoding is strict for complete lines.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [ValidateRange(0, [long]::MaxValue)]
+        [long]$StartOffset = 0
+    )
+
+    $Stream = $null
+    try {
+        $Stream = [IO.File]::Open($Path, [IO.FileMode]::Open, [IO.FileAccess]::Read, [IO.FileShare]::ReadWrite)
+        if ($Stream.Length -lt $StartOffset) {
+            $StartOffset = 0L
+        }
+        [void]$Stream.Seek($StartOffset, [IO.SeekOrigin]::Begin)
+
+        $Buffer = [byte[]]::new(8192)
+        $LineBytes = [Collections.Generic.List[byte]]::new()
+        $CurrentOffset = $StartOffset
+        $StrictUtf8 = [Text.UTF8Encoding]::new($false, $true)
+
+        while (($ReadCount = $Stream.Read($Buffer, 0, $Buffer.Length)) -gt 0) {
+            for ($Index = 0; $Index -lt $ReadCount; $Index++) {
+                $LineBytes.Add($Buffer[$Index])
+                $CurrentOffset++
+                if ($Buffer[$Index] -ne 0x0A) {
+                    continue
+                }
+
+                $Bytes = $LineBytes.ToArray()
+                if ($Bytes.Length -gt 0 -and $Bytes[-1] -eq 0x0A) {
+                    $Bytes = if ($Bytes.Length -gt 1) { $Bytes[0..($Bytes.Length - 2)] } else { [byte[]]::new(0) }
+                }
+                if ($Bytes.Length -gt 0 -and $Bytes[-1] -eq 0x0D) {
+                    $Bytes = if ($Bytes.Length -gt 1) { $Bytes[0..($Bytes.Length - 2)] } else { [byte[]]::new(0) }
+                }
+
+                $Record = $null
+                try {
+                    $LineText = $StrictUtf8.GetString($Bytes)
+                    if (-not [string]::IsNullOrWhiteSpace($LineText)) {
+                        $Record = $LineText | ConvertFrom-Json
+                    }
+                }
+                catch {
+                    $Record = $null
+                }
+
+                [pscustomobject]@{
+                    Record = $Record
+                    NextOffset = $CurrentOffset
+                }
+                $LineBytes.Clear()
+            }
+        }
+    }
+    catch {
+        # A locked or disappearing rollout is retried on the next rescan.
+    }
+    finally {
+        if ($null -ne $Stream) {
+            $Stream.Dispose()
+        }
+    }
+}
+
+function Get-TaskCompleteEvent {
+    <#
+    .SYNOPSIS
+    Extracts a Codex task_complete event from one parsed JSONL record.
+
+    .PARAMETER Record
+    The parsed outer rollout record.
+
+    .OUTPUTS
+    PSCustomObject. Returns event timestamp and sanitized turn ID, or null.
+    #>
+    param(
+        [AllowNull()]
+        [object]$Record
+    )
+
+    if ($null -eq $Record -or [string](Get-JsonProperty -InputObject $Record -Name 'type') -ne 'event_msg') {
+        return $null
+    }
+
+    $Payload = Get-JsonProperty -InputObject $Record -Name 'payload'
+    if ([string](Get-JsonProperty -InputObject $Payload -Name 'type') -ne 'task_complete') {
+        return $null
+    }
+
+    $Timestamp = [string](Get-JsonProperty -InputObject $Record -Name 'timestamp')
+    $ParsedTimestamp = [DateTimeOffset]::MinValue
+    if (-not [DateTimeOffset]::TryParse($Timestamp, [Globalization.CultureInfo]::InvariantCulture, [Globalization.DateTimeStyles]::AssumeUniversal, [ref]$ParsedTimestamp)) {
+        return $null
+    }
+
+    $TurnId = Normalize-CodexThreadId -InputValue (Get-JsonProperty -InputObject $Payload -Name 'turn_id')
+    if ($null -eq $TurnId) {
+        $TurnId = 'unknown'
+    }
+
+    return [pscustomobject]@{
+        Timestamp = $ParsedTimestamp
+        TurnId = $TurnId
+    }
+}
+
+function Invoke-StopHelper {
+    <#
+    .SYNOPSIS
+    Sends one synthetic Stop envelope to the Windows helper through stdin.
+
+    .PARAMETER ThreadId
+    The normalized user session UUID.
+
+    .PARAMETER TranscriptPath
+    The validated rollout path.
+
+    .PARAMETER TurnId
+    The sanitized completion turn UUID.
+
+    .PARAMETER Generation
+    The generation observed by this watcher scan. The helper rejects the
+    envelope when a newer explicit arm has replaced it.
+
+    .OUTPUTS
+    PSCustomObject. Returns `Handled` with a terminal status, or a generic
+    `not_handled`/`transient_failure` classification.
+
+    .NOTES
+    The helper owns the per-thread claim and notification attempt. This process
+    never places message or topic data on the command line or in output.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId,
+
+        [Parameter(Mandatory)]
+        [string]$TranscriptPath,
+
+        [Parameter(Mandatory)]
+        [string]$TurnId,
+
+        [Parameter(Mandatory)]
+        [string]$Generation
+    )
+
+    if (-not (Test-Path -LiteralPath $HelperPath -PathType Leaf)) {
+        return [pscustomobject]@{
+            Handled = $false
+            Status = 'transient_failure'
+        }
+    }
+
+    $PowerShellExecutable = Join-Path $PSHOME 'pwsh.exe'
+    if (-not (Test-Path -LiteralPath $PowerShellExecutable -PathType Leaf)) {
+        return [pscustomobject]@{
+            Handled = $false
+            Status = 'transient_failure'
+        }
+    }
+
+    $Envelope = [ordered]@{
+        operation = 'stop'
+        hook = [ordered]@{
+            hook_event_name = 'Stop'
+            session_id = $ThreadId
+            transcript_path = $TranscriptPath
+            turn_id = $TurnId
+            stop_hook_active = $false
+            expected_generation = $Generation
+        }
+    }
+    $RequestJson = $Envelope | ConvertTo-Json -Compress
+    $StartInfo = [Diagnostics.ProcessStartInfo]::new()
+    $StartInfo.FileName = $PowerShellExecutable
+    $StartInfo.UseShellExecute = $false
+    $StartInfo.CreateNoWindow = $true
+    $StartInfo.RedirectStandardInput = $true
+    $StartInfo.RedirectStandardOutput = $true
+    $StartInfo.RedirectStandardError = $true
+    $StartInfo.StandardInputEncoding = [Text.UTF8Encoding]::new($false)
+    $StartInfo.StandardOutputEncoding = [Text.UTF8Encoding]::new($false)
+    $StartInfo.StandardErrorEncoding = [Text.UTF8Encoding]::new($false)
+    [void]$StartInfo.ArgumentList.Add('-NoProfile')
+    [void]$StartInfo.ArgumentList.Add('-NonInteractive')
+    [void]$StartInfo.ArgumentList.Add('-File')
+    [void]$StartInfo.ArgumentList.Add($HelperPath)
+
+    $Process = $null
+    try {
+        $Process = [Diagnostics.Process]::new()
+        $Process.StartInfo = $StartInfo
+        if (-not $Process.Start()) {
+            return [pscustomobject]@{
+                Handled = $false
+                Status = 'transient_failure'
+            }
+        }
+
+        $OutputTask = $Process.StandardOutput.ReadToEndAsync()
+        $ErrorTask = $Process.StandardError.ReadToEndAsync()
+        $Process.StandardInput.Write($RequestJson)
+        $Process.StandardInput.Close()
+        if (-not $Process.WaitForExit(60000)) {
+            try {
+                $Process.Kill($true)
+            }
+            catch {
+                # The helper is already terminating; no retry is attempted.
+            }
+            return [pscustomobject]@{
+                Handled = $false
+                Status = 'transient_failure'
+            }
+        }
+
+        $OutputText = $OutputTask.GetAwaiter().GetResult()
+        [void]$ErrorTask.GetAwaiter().GetResult()
+        if ($Process.ExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($OutputText)) {
+            return [pscustomobject]@{
+                Handled = $false
+                Status = 'transient_failure'
+            }
+        }
+
+        $Result = $OutputText | ConvertFrom-Json
+        if ($Result.Handled -eq $true) {
+            $ResultStatus = [string](Get-JsonProperty -InputObject $Result -Name 'Status')
+            if ([string]::IsNullOrWhiteSpace($ResultStatus)) {
+                $ResultStatus = 'failure'
+            }
+            return [pscustomobject]@{
+                Handled = $true
+                Status = $ResultStatus
+            }
+        }
+
+        if ($Result.Ok -eq $true) {
+            return [pscustomobject]@{
+                Handled = $false
+                Status = 'not_handled'
+            }
+        }
+
+        return [pscustomobject]@{
+            Handled = $false
+            Status = 'transient_failure'
+        }
+    }
+    catch {
+        return [pscustomobject]@{
+            Handled = $false
+            Status = 'transient_failure'
+        }
+    }
+    finally {
+        if ($null -ne $Process) {
+            $Process.Dispose()
+        }
+    }
+}
+
+function Process-ActiveRequest {
+    <#
+    .SYNOPSIS
+    Scans validated user rollouts and handles the first eligible completion.
+
+    .PARAMETER Request
+    An active request object from Get-ActiveRequests.
+
+    .OUTPUTS
+    System.Boolean. Returns true when the helper consumed the request.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$Request
+    )
+
+    $Checkpoint = Read-Checkpoint -Request $Request
+    $ArmedAt = [DateTimeOffset]::MinValue
+    if (-not [DateTimeOffset]::TryParse(
+            $Checkpoint.ArmedAtUtc,
+            [Globalization.CultureInfo]::InvariantCulture,
+            [Globalization.DateTimeStyles]::AssumeUniversal,
+            [ref]$ArmedAt)) {
+        $ArmedAt = [DateTimeOffset]::UtcNow
+    }
+
+    $SessionsDirectory = Get-CodexSessionsDirectory
+    if ([string]::IsNullOrWhiteSpace($SessionsDirectory) -or
+        -not (Test-Path -LiteralPath $SessionsDirectory -PathType Container)) {
+        return $false
+    }
+
+    $RolloutFiles = @(Get-ChildItem -LiteralPath $SessionsDirectory -Recurse -File -Filter 'rollout-*.jsonl' -ErrorAction SilentlyContinue)
+    foreach ($RolloutFile in $RolloutFiles) {
+        $SessionId = Get-UserSessionId -Path $RolloutFile.FullName
+        if ($SessionId -ne $Request.ThreadId) {
+            continue
+        }
+
+        $Offset = 0L
+        if ($Checkpoint.Offsets.ContainsKey($RolloutFile.FullName)) {
+            $Offset = [long]$Checkpoint.Offsets[$RolloutFile.FullName]
+        }
+
+        $Handled = $false
+        $CurrentOffset = $Offset
+        foreach ($Line in @(Read-CompleteJsonLines -Path $RolloutFile.FullName -StartOffset $Offset)) {
+            $LineStartOffset = $CurrentOffset
+            $NextOffset = [long]$Line.NextOffset
+            if ($null -eq $Line.Record) {
+                $Checkpoint.Offsets[$RolloutFile.FullName] = $NextOffset
+                $CurrentOffset = $NextOffset
+                continue
+            }
+
+            $CompleteEvent = Get-TaskCompleteEvent -Record $Line.Record
+            if ($null -eq $CompleteEvent -or $CompleteEvent.Timestamp -lt $ArmedAt) {
+                $Checkpoint.Offsets[$RolloutFile.FullName] = $NextOffset
+                $CurrentOffset = $NextOffset
+                continue
+            }
+
+            $HelperResult = Invoke-StopHelper `
+                    -ThreadId $Request.ThreadId `
+                    -TranscriptPath $RolloutFile.FullName `
+                    -TurnId $CompleteEvent.TurnId `
+                    -Generation $Checkpoint.Generation
+            if ($null -eq $HelperResult) {
+                $HelperResult = [pscustomobject]@{
+                    Handled = $false
+                    Status = 'transient_failure'
+                }
+            }
+
+            if ($HelperResult.Handled -eq $true) {
+                $Handled = $true
+                break
+            }
+
+            # An eligible event is never checkpointed past unless the helper
+            # reports that this generation was claimed. This preserves the
+            # event for a later scan after either a transient helper failure or
+            # a benign no-op result; stale generations are rejected by the
+            # checkpoint revalidation and expected-generation guard.
+            $Checkpoint.Offsets[$RolloutFile.FullName] = $LineStartOffset
+            Save-Checkpoint -Request $Request -Checkpoint $Checkpoint
+            return $false
+        }
+
+        if ($Handled) {
+            return $true
+        }
+
+        Save-Checkpoint -Request $Request -Checkpoint $Checkpoint
+    }
+
+    return $false
+}
+
+function Start-RolloutWakeupWatcher {
+    <#
+    .SYNOPSIS
+    Creates an optional FileSystemWatcher used only to wake periodic scans.
+
+    .PARAMETER SessionsDirectory
+    The Codex sessions directory to observe.
+
+    .OUTPUTS
+    PSCustomObject. Returns the watcher and event source identifiers, or null
+    when the directory or watcher API is unavailable.
+
+    .NOTES
+    Detection remains driven by periodic rescan and persistent offsets; events
+    are hints and are never treated as completion records.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$SessionsDirectory
+    )
+
+    if ([string]::IsNullOrWhiteSpace($SessionsDirectory) -or
+        -not (Test-Path -LiteralPath $SessionsDirectory -PathType Container)) {
+        return $null
+    }
+
+    $Watcher = $null
+    $SourceIdentifiers = @(
+        "TaskCompleteNotifyChanged-$([Guid]::NewGuid().ToString('N'))"
+        "TaskCompleteNotifyCreated-$([Guid]::NewGuid().ToString('N'))"
+        "TaskCompleteNotifyRenamed-$([Guid]::NewGuid().ToString('N'))"
+    )
+    try {
+        $Watcher = [IO.FileSystemWatcher]::new()
+        $Watcher.Path = $SessionsDirectory
+        $Watcher.Filter = 'rollout-*.jsonl'
+        $Watcher.IncludeSubdirectories = $true
+        $Watcher.NotifyFilter = [IO.NotifyFilters]::LastWrite -bor [IO.NotifyFilters]::FileName -bor [IO.NotifyFilters]::Size
+        $Watcher.EnableRaisingEvents = $true
+        Register-ObjectEvent -InputObject $Watcher -EventName Changed -SourceIdentifier $SourceIdentifiers[0] | Out-Null
+        Register-ObjectEvent -InputObject $Watcher -EventName Created -SourceIdentifier $SourceIdentifiers[1] | Out-Null
+        Register-ObjectEvent -InputObject $Watcher -EventName Renamed -SourceIdentifier $SourceIdentifiers[2] | Out-Null
+        return [pscustomobject]@{
+            Watcher = $Watcher
+            SourceIdentifiers = $SourceIdentifiers
+        }
+    }
+    catch {
+        if ($null -ne $Watcher) {
+            $Watcher.Dispose()
+        }
+        return $null
+    }
+}
+
+function Stop-RolloutWakeupWatcher {
+    <#
+    .SYNOPSIS
+    Disposes the optional FileSystemWatcher and its event subscriptions.
+
+    .PARAMETER WatchContext
+    The object returned by Start-RolloutWakeupWatcher.
+
+    .OUTPUTS
+    None. Event registrations and the watcher are released.
+    #>
+    param(
+        [AllowNull()]
+        [object]$WatchContext
+    )
+
+    if ($null -eq $WatchContext) {
+        return
+    }
+
+    foreach ($SourceIdentifier in @($WatchContext.SourceIdentifiers)) {
+        Unregister-Event -SourceIdentifier $SourceIdentifier -ErrorAction SilentlyContinue
+        Get-Event -SourceIdentifier $SourceIdentifier -ErrorAction SilentlyContinue | Remove-Event -ErrorAction SilentlyContinue
+    }
+
+    if ($null -ne $WatchContext.Watcher) {
+        $WatchContext.Watcher.Dispose()
+    }
+}
+
+function Wait-ForRolloutWakeup {
+    <#
+    .SYNOPSIS
+    Waits for a watcher hint while preserving a periodic rescan cadence.
+
+    .PARAMETER WatchContext
+    The optional watcher context.
+
+    .PARAMETER TimeoutMilliseconds
+    Maximum wait before the next periodic scan.
+
+    .OUTPUTS
+    None. Pending events are discarded after waking because offsets are the
+    source of truth.
+    #>
+    param(
+        [AllowNull()]
+        [object]$WatchContext,
+
+        [ValidateRange(100, 60000)]
+        [int]$TimeoutMilliseconds
+    )
+
+    if ($null -eq $WatchContext) {
+        Start-Sleep -Milliseconds $TimeoutMilliseconds
+        return
+    }
+
+    # Wait-Event accepts a single string source and an integer timeout. This
+    # isolated process owns only the registrations below, so wait without a
+    # source filter and drain each known source individually afterward.
+    $WholeSeconds = [int][Math]::Floor([double]$TimeoutMilliseconds / 1000.0)
+    $RemainderMilliseconds = $TimeoutMilliseconds - ($WholeSeconds * 1000)
+    $Event = Wait-Event -Timeout $WholeSeconds
+    if ($null -ne $Event) {
+        Remove-Event -EventIdentifier $Event.EventIdentifier -ErrorAction SilentlyContinue
+    }
+    elseif ($RemainderMilliseconds -gt 0) {
+        Start-Sleep -Milliseconds $RemainderMilliseconds
+    }
+
+    foreach ($SourceIdentifier in @($WatchContext.SourceIdentifiers)) {
+        foreach ($PendingEvent in @(Get-Event -SourceIdentifier $SourceIdentifier -ErrorAction SilentlyContinue)) {
+            Remove-Event -EventIdentifier $PendingEvent.EventIdentifier -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Get-ActiveRequestCount {
+    <#
+    .SYNOPSIS
+    Returns the number of armed requests visible at a coordination point.
+
+    .OUTPUTS
+    System.Int32. Returns the current active request count.
+    #>
+    return @((Get-ActiveRequests)).Count
+}
+
+$WatcherStream = $null
+$WatchContext = $null
+Initialize-WatcherDirectories
+$WatcherStream = Acquire-WatcherLock
+if ($null -eq $WatcherStream) {
+    exit 0
+}
+
+try {
+    $InitialSessionsDirectory = Get-CodexSessionsDirectory
+    $WatchContext = Start-RolloutWakeupWatcher -SessionsDirectory $InitialSessionsDirectory
+
+    while ($true) {
+        $ActiveRequests = @(Get-ActiveRequests)
+        if ($ActiveRequests.Count -eq 0) {
+            $CoordinationStream = Acquire-CoordinationLock
+            if ($null -eq $CoordinationStream) {
+                if ($Once) {
+                    break
+                }
+                Start-Sleep -Milliseconds $PollIntervalMilliseconds
+                continue
+            }
+
+            try {
+                if ((Get-ActiveRequestCount) -eq 0) {
+                    # Release the lifetime lock while still holding coordination.
+                    # arm cannot publish a request until this stream is closed.
+                    Stop-RolloutWakeupWatcher -WatchContext $WatchContext
+                    $WatchContext = $null
+                    $WatcherStream.Dispose()
+                    $WatcherStream = $null
+                    break
+                }
+            }
+            finally {
+                $CoordinationStream.Dispose()
+            }
+            continue
+        }
+
+        foreach ($Request in $ActiveRequests) {
+            [void](Process-ActiveRequest -Request $Request)
+        }
+
+        if ($Once) {
+            break
+        }
+        Wait-ForRolloutWakeup -WatchContext $WatchContext -TimeoutMilliseconds $PollIntervalMilliseconds
+    }
+}
+finally {
+    Stop-RolloutWakeupWatcher -WatchContext $WatchContext
+    if ($null -ne $WatcherStream) {
+        $WatcherStream.Dispose()
+    }
+}

--- a/.agents/skills/task-complete-notify/scripts/codex-watcher.ps1
+++ b/.agents/skills/task-complete-notify/scripts/codex-watcher.ps1
@@ -13,10 +13,8 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
-[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
 
 $ScriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
-$SkillDirectory = Split-Path -Parent $ScriptDirectory
 
 function Resolve-CodexHome {
     <#
@@ -56,18 +54,22 @@ function Resolve-CodexHome {
 }
 
 $CodexHome = Resolve-CodexHome
-$StateDirectory = if ([string]::IsNullOrWhiteSpace($CodexHome)) {
-    Join-Path $SkillDirectory '.task-complete-notify.invalid'
+$StateDirectory = $null
+$RequestDirectory = $null
+$LockDirectory = $null
+$CheckpointDirectory = $null
+$TerminalDirectory = $null
+$WatcherLockPath = $null
+$CoordinationLockPath = $null
+if (-not [string]::IsNullOrWhiteSpace($CodexHome)) {
+    $StateDirectory = Join-Path $CodexHome '.task-complete-notify'
+    $RequestDirectory = Join-Path $StateDirectory 'requests'
+    $LockDirectory = Join-Path $StateDirectory 'locks'
+    $CheckpointDirectory = Join-Path $StateDirectory 'checkpoints'
+    $TerminalDirectory = Join-Path $StateDirectory 'terminal'
+    $WatcherLockPath = Join-Path $StateDirectory 'watcher.lock'
+    $CoordinationLockPath = Join-Path $StateDirectory 'coordination.lock'
 }
-else {
-    Join-Path $CodexHome '.task-complete-notify'
-}
-$RequestDirectory = Join-Path $StateDirectory 'requests'
-$LockDirectory = Join-Path $StateDirectory 'locks'
-$CheckpointDirectory = Join-Path $StateDirectory 'checkpoints'
-$TerminalDirectory = Join-Path $StateDirectory 'terminal'
-$WatcherLockPath = Join-Path $StateDirectory 'watcher.lock'
-$CoordinationLockPath = Join-Path $StateDirectory 'coordination.lock'
 $HelperPath = if ([string]::IsNullOrWhiteSpace($HelperScriptPath)) {
     Join-Path $ScriptDirectory 'windows-helper.ps1'
 }
@@ -1189,7 +1191,12 @@ function Get-ActiveRequestCount {
 
 $WatcherStream = $null
 $WatchContext = $null
-Initialize-WatcherDirectories
+try {
+    Initialize-WatcherDirectories
+}
+catch {
+    exit 1
+}
 $WatcherStream = Acquire-WatcherLock
 if ($null -eq $WatcherStream) {
     exit 0

--- a/.agents/skills/task-complete-notify/scripts/diagnostics/send-random-message.ps1
+++ b/.agents/skills/task-complete-notify/scripts/diagnostics/send-random-message.ps1
@@ -1,0 +1,159 @@
+#requires -Version 7.4
+
+[CmdletBinding()]
+param(
+    [ValidateRange(1, 4096)]
+    [int]$Length = 24
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-RandomText {
+<#
+.SYNOPSIS
+Generates a random ASCII string with the requested length.
+
+.DESCRIPTION
+Uses a cryptographically strong random byte source and a printable alphabet
+so the generated value can be sent as an ntfy message body.
+
+.PARAMETER Length
+Number of characters to generate.
+
+.OUTPUTS
+System.String
+#>
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateRange(1, 4096)]
+        [int]$Length
+    )
+
+    $Alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    $RandomBytes = [byte[]]::new($Length)
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($RandomBytes)
+
+    $Characters = [char[]]::new($Length)
+    for ($Index = 0; $Index -lt $Length; $Index++) {
+        $Characters[$Index] = $Alphabet[$RandomBytes[$Index] % $Alphabet.Length]
+    }
+
+    return -join $Characters
+}
+
+function Get-NtfyTopicUri {
+<#
+.SYNOPSIS
+Builds the fixed ntfy.sh topic URI from the NTFY_TOPIC value.
+
+.DESCRIPTION
+Trims surrounding whitespace, rejects line breaks, and URI-encodes the topic
+as one path segment so environment input cannot alter the request target.
+
+.PARAMETER Topic
+Topic name read from the NTFY_TOPIC environment variable.
+
+.OUTPUTS
+System.Uri
+#>
+    [OutputType([Uri])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Topic
+    )
+
+    if ($Topic -match '[\x00-\x1F\x7F]') {
+        throw 'NTFY_TOPIC must not contain control characters.'
+    }
+
+    $TrimmedTopic = $Topic.Trim()
+    if ([string]::IsNullOrWhiteSpace($TrimmedTopic)) {
+        throw 'NTFY_TOPIC is empty.'
+    }
+    if ($TrimmedTopic -notmatch '^[-_A-Za-z0-9]{1,64}$') {
+        throw 'NTFY_TOPIC must contain only ASCII letters, digits, hyphens, or underscores and be at most 64 characters.'
+    }
+
+    $EncodedTopic = [Uri]::EscapeDataString($TrimmedTopic)
+    return [Uri]::new("https://ntfy.sh/$EncodedTopic")
+}
+
+function Send-NtfyNotification {
+<#
+.SYNOPSIS
+Posts one notification and requires an HTTP 2xx response.
+
+.DESCRIPTION
+Sends the supplied message to the fixed ntfy.sh endpoint. The title is sent
+through ntfy's X-Title header, and non-success HTTP responses are surfaced as
+errors so a successful process start is not mistaken for delivery success.
+
+.PARAMETER Uri
+The ntfy topic URI.
+
+.PARAMETER Title
+Notification title.
+
+.PARAMETER Message
+Notification body.
+
+.OUTPUTS
+System.Object
+#>
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory)]
+        [Uri]$Uri,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Title,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Message
+    )
+
+    try {
+        $Response = Invoke-WebRequest `
+            -Uri $Uri `
+            -Method Post `
+            -Headers @{ 'X-Title' = $Title } `
+            -Body $Message `
+            -ContentType 'text/plain; charset=utf-8' `
+            -ConnectionTimeoutSeconds 30 `
+            -OperationTimeoutSeconds 30 `
+            -MaximumRedirection 0 `
+            -SkipHttpErrorCheck
+    }
+    catch {
+        throw 'ntfy request failed before receiving an HTTP response.'
+    }
+
+    $StatusCode = [int]$Response.StatusCode
+    if ($StatusCode -lt 200 -or $StatusCode -gt 299) {
+        throw "ntfy returned HTTP $StatusCode."
+    }
+
+    return $Response
+}
+
+$Topic = [Environment]::GetEnvironmentVariable(
+    'NTFY_TOPIC',
+    [EnvironmentVariableTarget]::Process
+)
+if ([string]::IsNullOrWhiteSpace($Topic)) {
+    throw 'Set env:NTFY_TOPIC before running this script.'
+}
+
+$RandomText = Get-RandomText -Length $Length
+$Response = Send-NtfyNotification `
+    -Uri (Get-NtfyTopicUri -Topic $Topic) `
+    -Title 'task-complete-notify: fixed title / variable message' `
+    -Message $RandomText
+
+[Console]::Out.WriteLine('Sent message-variable ntfy test.')
+[Console]::Out.WriteLine("Random message ($Length chars): $RandomText")
+[Console]::Out.WriteLine("HTTP status: $([int]$Response.StatusCode)")

--- a/.agents/skills/task-complete-notify/scripts/diagnostics/send-random-title.ps1
+++ b/.agents/skills/task-complete-notify/scripts/diagnostics/send-random-title.ps1
@@ -1,0 +1,160 @@
+#requires -Version 7.4
+
+[CmdletBinding()]
+param(
+    [ValidateRange(1, 256)]
+    [int]$Length = 24
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-RandomText {
+<#
+.SYNOPSIS
+Generates a random ASCII string with the requested length.
+
+.DESCRIPTION
+Uses a cryptographically strong random byte source and a header-safe alphabet
+so the generated value can be sent as an ntfy title without newline or control
+characters.
+
+.PARAMETER Length
+Number of characters to generate.
+
+.OUTPUTS
+System.String
+#>
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateRange(1, 256)]
+        [int]$Length
+    )
+
+    $Alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    $RandomBytes = [byte[]]::new($Length)
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($RandomBytes)
+
+    $Characters = [char[]]::new($Length)
+    for ($Index = 0; $Index -lt $Length; $Index++) {
+        $Characters[$Index] = $Alphabet[$RandomBytes[$Index] % $Alphabet.Length]
+    }
+
+    return -join $Characters
+}
+
+function Get-NtfyTopicUri {
+<#
+.SYNOPSIS
+Builds the fixed ntfy.sh topic URI from the NTFY_TOPIC value.
+
+.DESCRIPTION
+Trims surrounding whitespace, rejects line breaks, and URI-encodes the topic
+as one path segment so environment input cannot alter the request target.
+
+.PARAMETER Topic
+Topic name read from the NTFY_TOPIC environment variable.
+
+.OUTPUTS
+System.Uri
+#>
+    [OutputType([Uri])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Topic
+    )
+
+    if ($Topic -match '[\x00-\x1F\x7F]') {
+        throw 'NTFY_TOPIC must not contain control characters.'
+    }
+
+    $TrimmedTopic = $Topic.Trim()
+    if ([string]::IsNullOrWhiteSpace($TrimmedTopic)) {
+        throw 'NTFY_TOPIC is empty.'
+    }
+    if ($TrimmedTopic -notmatch '^[-_A-Za-z0-9]{1,64}$') {
+        throw 'NTFY_TOPIC must contain only ASCII letters, digits, hyphens, or underscores and be at most 64 characters.'
+    }
+
+    $EncodedTopic = [Uri]::EscapeDataString($TrimmedTopic)
+    return [Uri]::new("https://ntfy.sh/$EncodedTopic")
+}
+
+function Send-NtfyNotification {
+<#
+.SYNOPSIS
+Posts one notification and requires an HTTP 2xx response.
+
+.DESCRIPTION
+Sends the supplied message to the fixed ntfy.sh endpoint. The title is sent
+through ntfy's X-Title header, and non-success HTTP responses are surfaced as
+errors so a successful process start is not mistaken for delivery success.
+
+.PARAMETER Uri
+The ntfy topic URI.
+
+.PARAMETER Title
+Notification title.
+
+.PARAMETER Message
+Notification body.
+
+.OUTPUTS
+System.Object
+#>
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory)]
+        [Uri]$Uri,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Title,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Message
+    )
+
+    try {
+        $Response = Invoke-WebRequest `
+            -Uri $Uri `
+            -Method Post `
+            -Headers @{ 'X-Title' = $Title } `
+            -Body $Message `
+            -ContentType 'text/plain; charset=utf-8' `
+            -ConnectionTimeoutSeconds 30 `
+            -OperationTimeoutSeconds 30 `
+            -MaximumRedirection 0 `
+            -SkipHttpErrorCheck
+    }
+    catch {
+        throw 'ntfy request failed before receiving an HTTP response.'
+    }
+
+    $StatusCode = [int]$Response.StatusCode
+    if ($StatusCode -lt 200 -or $StatusCode -gt 299) {
+        throw "ntfy returned HTTP $StatusCode."
+    }
+
+    return $Response
+}
+
+$Topic = [Environment]::GetEnvironmentVariable(
+    'NTFY_TOPIC',
+    [EnvironmentVariableTarget]::Process
+)
+if ([string]::IsNullOrWhiteSpace($Topic)) {
+    throw 'Set env:NTFY_TOPIC before running this script.'
+}
+
+$RandomText = Get-RandomText -Length $Length
+$Response = Send-NtfyNotification `
+    -Uri (Get-NtfyTopicUri -Topic $Topic) `
+    -Title $RandomText `
+    -Message 'task-complete-notify: fixed message / variable title'
+
+[Console]::Out.WriteLine('Sent title-variable ntfy test.')
+[Console]::Out.WriteLine("Random title ($Length chars): $RandomText")
+[Console]::Out.WriteLine("HTTP status: $([int]$Response.StatusCode)")

--- a/.agents/skills/task-complete-notify/scripts/notify.ps1
+++ b/.agents/skills/task-complete-notify/scripts/notify.ps1
@@ -1,0 +1,217 @@
+#requires -Version 7.4
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
+
+function Assert-NotificationMessage {
+    <#
+    .SYNOPSIS
+    Validates the literal message that will be sent to ntfy.
+
+    .DESCRIPTION
+    Enforces the one-line, control-character, Unicode, and UTF-8 byte-length
+    contract without including the message value in any exception text.
+
+    .PARAMETER Message
+    The literal message to validate.
+
+    .OUTPUTS
+    System.String. Returns the unchanged message after validation.
+
+    .NOTES
+    The caller is responsible for keeping the returned value out of logs and
+    user-visible diagnostics.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Message
+    )
+
+    if ([string]::IsNullOrEmpty($Message) -or [string]::IsNullOrWhiteSpace($Message)) {
+        throw 'message_invalid'
+    }
+
+    if ([char]::IsWhiteSpace($Message[0]) -or [char]::IsWhiteSpace($Message[$Message.Length - 1])) {
+        throw 'message_invalid'
+    }
+
+    for ($CharacterIndex = 0; $CharacterIndex -lt $Message.Length; $CharacterIndex++) {
+        $Character = $Message[$CharacterIndex]
+        $CodePoint = [int][char]$Character
+
+        if ($CodePoint -eq 0x2028 -or $CodePoint -eq 0x2029) {
+            throw 'message_invalid'
+        }
+
+        if ([char]::IsHighSurrogate($Character)) {
+            if ($CharacterIndex + 1 -ge $Message.Length -or -not [char]::IsLowSurrogate($Message[$CharacterIndex + 1])) {
+                throw 'message_invalid'
+            }
+
+            $CharacterIndex++
+            continue
+        }
+
+        if ([char]::IsLowSurrogate($Character) -or [char]::IsControl($Character)) {
+            throw 'message_invalid'
+        }
+    }
+
+    try {
+        $Utf8Encoding = [Text.UTF8Encoding]::new($false, $true)
+        $Utf8Bytes = $Utf8Encoding.GetBytes($Message)
+    }
+    catch {
+        throw 'message_invalid'
+    }
+
+    if ($Utf8Bytes.Length -gt 256) {
+        throw 'message_invalid'
+    }
+
+    return $Message
+}
+
+function Get-NtfyTopic {
+    <#
+    .SYNOPSIS
+    Reads and validates the ntfy topic from the process environment.
+
+    .OUTPUTS
+    System.String. Returns a validated topic or throws a generic topic error.
+
+    .NOTES
+    The topic value is never included in output, state, or exception text.
+    #>
+    $Topic = [Environment]::GetEnvironmentVariable('NTFY_TOPIC', 'Process')
+    if ([string]::IsNullOrWhiteSpace($Topic)) {
+        throw 'topic_missing'
+    }
+
+    $Topic = $Topic.Trim()
+    if ($Topic -notmatch '^[-_A-Za-z0-9]{1,64}$') {
+        throw 'topic_invalid'
+    }
+
+    return $Topic
+}
+
+function Invoke-NtfyPublish {
+    <#
+    .SYNOPSIS
+    Sends one message-body-only request to the fixed ntfy server.
+
+    .PARAMETER Message
+    The already validated message body.
+
+    .OUTPUTS
+    PSCustomObject. Returns an outcome with only a success flag and a generic
+    reason; no topic, URL, response body, or message is returned.
+
+    .NOTES
+    A final HTTP 200-299 is the only successful result. Redirects and all
+    transport failures are terminal for the caller's one-shot generation.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Message
+    )
+
+    try {
+        $ValidatedMessage = Assert-NotificationMessage -Message $Message
+        $Topic = Get-NtfyTopic
+        $EncodedTopic = [Uri]::EscapeDataString($Topic)
+        $Uri = "https://ntfy.sh/$EncodedTopic"
+
+        $Response = Invoke-WebRequest `
+            -Method Post `
+            -Uri $Uri `
+            -ContentType 'text/plain; charset=utf-8' `
+            -Body $ValidatedMessage `
+            -ConnectionTimeoutSeconds 10 `
+            -OperationTimeoutSeconds 20 `
+            -MaximumRedirection 0 `
+            -SkipHttpErrorCheck
+
+        $StatusCode = [int]$Response.StatusCode
+        if ($StatusCode -ge 200 -and $StatusCode -le 299) {
+            return [pscustomobject]@{
+                Ok = $true
+                Reason = 'success'
+            }
+        }
+
+        return [pscustomobject]@{
+            Ok = $false
+            Reason = 'http_failure'
+        }
+    }
+    catch {
+        $Reason = switch -Regex ($_.Exception.Message) {
+            '^topic_missing$' { 'topic_missing'; break }
+            '^topic_invalid$' { 'topic_invalid'; break }
+            '^message_invalid$' { 'message_invalid'; break }
+            default { 'transport_failure' }
+        }
+
+        return [pscustomobject]@{
+            Ok = $false
+            Reason = $Reason
+        }
+    }
+}
+
+function Read-NotificationRequest {
+    <#
+    .SYNOPSIS
+    Reads the helper-to-notifier JSON envelope from standard input.
+
+    .OUTPUTS
+    PSCustomObject. Returns a request containing only the validated message.
+
+    .NOTES
+    Invalid input is reported with a generic error and never echoed.
+    #>
+    $RequestText = [Console]::In.ReadToEnd()
+    if ([string]::IsNullOrWhiteSpace($RequestText)) {
+        throw 'request_invalid'
+    }
+
+    try {
+        $Request = $RequestText | ConvertFrom-Json
+    }
+    catch {
+        throw 'request_invalid'
+    }
+
+    if (-not $Request.PSObject.Properties.Name.Contains('message')) {
+        throw 'request_invalid'
+    }
+
+    $Message = [string]$Request.message
+    [void](Assert-NotificationMessage -Message $Message)
+
+    return [pscustomobject]@{
+        Message = $Message
+    }
+}
+
+try {
+    $NotificationRequest = Read-NotificationRequest
+    $NotificationResult = Invoke-NtfyPublish -Message $NotificationRequest.Message
+}
+catch {
+    $NotificationResult = [pscustomobject]@{
+        Ok = $false
+        Reason = 'request_invalid'
+    }
+}
+
+[Console]::Out.WriteLine(($NotificationResult | ConvertTo-Json -Compress))

--- a/.agents/skills/task-complete-notify/scripts/notify.ps1
+++ b/.agents/skills/task-complete-notify/scripts/notify.ps1
@@ -6,7 +6,6 @@ param()
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
-[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
 
 function Assert-NotificationMessage {
     <#
@@ -179,27 +178,45 @@ function Read-NotificationRequest {
     .NOTES
     Invalid input is reported with a generic error and never echoed.
     #>
-    $RequestText = [Console]::In.ReadToEnd()
-    if ([string]::IsNullOrWhiteSpace($RequestText)) {
-        throw 'request_invalid'
-    }
-
+    $InputStream = $null
+    $InputReader = $null
     try {
-        $Request = $RequestText | ConvertFrom-Json
-    }
-    catch {
-        throw 'request_invalid'
-    }
+        $InputStream = [Console]::OpenStandardInput()
+        $InputReader = [IO.StreamReader]::new(
+            $InputStream,
+            [Text.UTF8Encoding]::new($false),
+            $true
+        )
+        $RequestText = $InputReader.ReadToEnd()
+        if ([string]::IsNullOrWhiteSpace($RequestText)) {
+            throw 'request_invalid'
+        }
 
-    if (-not $Request.PSObject.Properties.Name.Contains('message')) {
-        throw 'request_invalid'
+        try {
+            $Request = $RequestText | ConvertFrom-Json
+        }
+        catch {
+            throw 'request_invalid'
+        }
+
+        if (-not $Request.PSObject.Properties.Name.Contains('message')) {
+            throw 'request_invalid'
+        }
+
+        $Message = [string]$Request.message
+        [void](Assert-NotificationMessage -Message $Message)
+
+        return [pscustomobject]@{
+            Message = $Message
+        }
     }
-
-    $Message = [string]$Request.message
-    [void](Assert-NotificationMessage -Message $Message)
-
-    return [pscustomobject]@{
-        Message = $Message
+    finally {
+        if ($null -ne $InputReader) {
+            $InputReader.Dispose()
+        }
+        if ($null -ne $InputStream) {
+            $InputStream.Dispose()
+        }
     }
 }
 

--- a/.agents/skills/task-complete-notify/scripts/windows-helper.ps1
+++ b/.agents/skills/task-complete-notify/scripts/windows-helper.ps1
@@ -6,10 +6,9 @@ param()
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
-[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
 
 $ScriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
-$SkillDirectory = Split-Path -Parent $ScriptDirectory
+$NotifierTimeoutMilliseconds = 35000
 
 function Resolve-CodexHome {
     <#
@@ -49,19 +48,22 @@ function Resolve-CodexHome {
 }
 
 $CodexHome = Resolve-CodexHome
-$StateDirectory = if ([string]::IsNullOrWhiteSpace($CodexHome)) {
-    # Keep invalid-home failures from creating any user-visible runtime path.
-    Join-Path $SkillDirectory '.task-complete-notify.invalid'
+$StateDirectory = $null
+$RequestDirectory = $null
+$LockDirectory = $null
+$CheckpointDirectory = $null
+$TerminalDirectory = $null
+$CoordinationLockPath = $null
+$WatcherLockPath = $null
+if (-not [string]::IsNullOrWhiteSpace($CodexHome)) {
+    $StateDirectory = Join-Path $CodexHome '.task-complete-notify'
+    $RequestDirectory = Join-Path $StateDirectory 'requests'
+    $LockDirectory = Join-Path $StateDirectory 'locks'
+    $CheckpointDirectory = Join-Path $StateDirectory 'checkpoints'
+    $TerminalDirectory = Join-Path $StateDirectory 'terminal'
+    $CoordinationLockPath = Join-Path $StateDirectory 'coordination.lock'
+    $WatcherLockPath = Join-Path $StateDirectory 'watcher.lock'
 }
-else {
-    Join-Path $CodexHome '.task-complete-notify'
-}
-$RequestDirectory = Join-Path $StateDirectory 'requests'
-$LockDirectory = Join-Path $StateDirectory 'locks'
-$CheckpointDirectory = Join-Path $StateDirectory 'checkpoints'
-$TerminalDirectory = Join-Path $StateDirectory 'terminal'
-$CoordinationLockPath = Join-Path $StateDirectory 'coordination.lock'
-$WatcherLockPath = Join-Path $StateDirectory 'watcher.lock'
 $NotifyScriptPath = Join-Path $ScriptDirectory 'notify.ps1'
 $WatcherScriptPath = Join-Path $ScriptDirectory 'codex-watcher.ps1'
 
@@ -1023,7 +1025,7 @@ function Invoke-NotificationScript {
             $ErrorTask = $NotifierProcess.StandardError.ReadToEndAsync()
             $NotifierProcess.StandardInput.Write($RequestJson)
             $NotifierProcess.StandardInput.Close()
-            if (-not $NotifierProcess.WaitForExit(30000)) {
+            if (-not $NotifierProcess.WaitForExit($NotifierTimeoutMilliseconds)) {
                 try {
                     $NotifierProcess.Kill($true)
                 }
@@ -1776,8 +1778,16 @@ function Invoke-HelperRequest {
 }
 
 $HelperResult = $null
+$InputStream = $null
+$InputReader = $null
 try {
-    $RequestText = [Console]::In.ReadToEnd()
+    $InputStream = [Console]::OpenStandardInput()
+    $InputReader = [IO.StreamReader]::new(
+        $InputStream,
+        [Text.UTF8Encoding]::new($false),
+        $true
+    )
+    $RequestText = $InputReader.ReadToEnd()
     if ([string]::IsNullOrWhiteSpace($RequestText)) {
         throw 'request_invalid'
     }
@@ -1789,6 +1799,14 @@ catch {
     $HelperResult = [pscustomobject]@{
         Ok = $false
         Status = 'request_invalid'
+    }
+}
+finally {
+    if ($null -ne $InputReader) {
+        $InputReader.Dispose()
+    }
+    if ($null -ne $InputStream) {
+        $InputStream.Dispose()
     }
 }
 

--- a/.agents/skills/task-complete-notify/scripts/windows-helper.ps1
+++ b/.agents/skills/task-complete-notify/scripts/windows-helper.ps1
@@ -1,0 +1,1795 @@
+#requires -Version 7.4
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
+
+$ScriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillDirectory = Split-Path -Parent $ScriptDirectory
+
+function Resolve-CodexHome {
+    <#
+    .SYNOPSIS
+    Resolves the Codex home used by this helper process.
+
+    .OUTPUTS
+    System.String. Returns an absolute Codex home path, or null when the
+    configured path cannot be resolved.
+
+    .NOTES
+    The process environment is the only selector. The caller must not infer a
+    different home from the target text or from another provider's settings.
+    #>
+    $ConfiguredHome = [Environment]::GetEnvironmentVariable('CODEX_HOME', 'Process')
+    if ([string]::IsNullOrWhiteSpace($ConfiguredHome)) {
+        $UserProfile = [Environment]::GetFolderPath('UserProfile')
+        if ([string]::IsNullOrWhiteSpace($UserProfile)) {
+            return $null
+        }
+
+        $ConfiguredHome = Join-Path $UserProfile '.codex'
+    }
+
+    try {
+        $ResolvedHome = [IO.Path]::GetFullPath($ConfiguredHome)
+    }
+    catch {
+        return $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($ResolvedHome)) {
+        return $null
+    }
+
+    return $ResolvedHome
+}
+
+$CodexHome = Resolve-CodexHome
+$StateDirectory = if ([string]::IsNullOrWhiteSpace($CodexHome)) {
+    # Keep invalid-home failures from creating any user-visible runtime path.
+    Join-Path $SkillDirectory '.task-complete-notify.invalid'
+}
+else {
+    Join-Path $CodexHome '.task-complete-notify'
+}
+$RequestDirectory = Join-Path $StateDirectory 'requests'
+$LockDirectory = Join-Path $StateDirectory 'locks'
+$CheckpointDirectory = Join-Path $StateDirectory 'checkpoints'
+$TerminalDirectory = Join-Path $StateDirectory 'terminal'
+$CoordinationLockPath = Join-Path $StateDirectory 'coordination.lock'
+$WatcherLockPath = Join-Path $StateDirectory 'watcher.lock'
+$NotifyScriptPath = Join-Path $ScriptDirectory 'notify.ps1'
+$WatcherScriptPath = Join-Path $ScriptDirectory 'codex-watcher.ps1'
+
+function Get-ObjectPropertyValue {
+    <#
+    .SYNOPSIS
+    Reads a property from an arbitrary JSON-derived object without strict-mode errors.
+
+    .PARAMETER InputObject
+    The object whose property should be read.
+
+    .PARAMETER PropertyName
+    The exact property name to read.
+
+    .OUTPUTS
+    System.Object. Returns the property value or null when it is absent.
+    #>
+    param(
+        [AllowNull()]
+        [object]$InputObject,
+
+        [Parameter(Mandatory)]
+        [string]$PropertyName
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    if ($InputObject -is [Collections.IDictionary] -and $InputObject.Contains($PropertyName)) {
+        return $InputObject[$PropertyName]
+    }
+
+    $Property = $InputObject.PSObject.Properties[$PropertyName]
+    if ($null -eq $Property) {
+        return $null
+    }
+
+    return $Property.Value
+}
+
+function Normalize-CodexThreadId {
+    <#
+    .SYNOPSIS
+    Normalizes a canonical Codex thread URI or raw UUID.
+
+    .PARAMETER InputValue
+    The canonical `codex://threads/<UUID>` value or raw UUID shorthand.
+
+    .OUTPUTS
+    System.String. Returns a lowercase UUID in dashed form.
+
+    .NOTES
+    The legacy `codex://<UUID>` form and URI decorations are intentionally rejected.
+    #>
+    param(
+        [AllowNull()]
+        [string]$InputValue
+    )
+
+    if ([string]::IsNullOrWhiteSpace($InputValue)) {
+        throw 'thread_invalid'
+    }
+
+    $UuidText = $null
+    if ($InputValue -match '^codex://threads/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$') {
+        $UuidText = $Matches[1]
+    }
+    elseif ($InputValue -match '^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$') {
+        $UuidText = $Matches[1]
+    }
+    else {
+        throw 'thread_invalid'
+    }
+
+    $GuidValue = [Guid]::Empty
+    if (-not [Guid]::TryParse($UuidText, [ref]$GuidValue)) {
+        throw 'thread_invalid'
+    }
+
+    return $GuidValue.ToString('D').ToLowerInvariant()
+}
+
+function Extract-ArmThreadId {
+    <#
+    .SYNOPSIS
+    Extracts one explicit Codex thread UUID from an arm input string.
+
+    .PARAMETER InputValue
+    Text containing a raw UUID or a canonical Codex thread URI.
+
+    .OUTPUTS
+    System.String. Returns one lowercase UUID.
+
+    .NOTES
+    This relaxed parser is intentionally limited to the external arm boundary.
+    Internal hook, metadata, and state values continue to use the strict
+    normalizer. Zero candidates, multiple distinct candidates, malformed
+    Codex URIs, and inputs over 4 KiB UTF-8 are rejected without echoing text.
+    #>
+    param(
+        [AllowNull()]
+        [string]$InputValue
+    )
+
+    if ([string]::IsNullOrWhiteSpace($InputValue)) {
+        throw 'thread_invalid'
+    }
+
+    try {
+        $Utf8Encoding = [Text.UTF8Encoding]::new($false, $true)
+        if ($Utf8Encoding.GetByteCount($InputValue) -gt 4096) {
+            throw 'thread_invalid'
+        }
+    }
+    catch {
+        throw 'thread_invalid'
+    }
+
+    $UuidPattern = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+    $UuidBoundaryPattern = "(?<![0-9A-Za-z_-])($UuidPattern)(?![0-9A-Za-z_-])"
+    $CodexUriMatches = [regex]::Matches($InputValue, 'codex://')
+    foreach ($CodexUriMatch in $CodexUriMatches) {
+        $UriSuffix = $InputValue.Substring($CodexUriMatch.Index)
+        if ($UriSuffix -notmatch ("^codex://threads/" + $UuidPattern + '(?![0-9A-Za-z_/?#-])')) {
+            throw 'thread_invalid'
+        }
+    }
+
+    $Candidates = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($UuidMatch in [regex]::Matches($InputValue, $UuidBoundaryPattern)) {
+        $GuidValue = [Guid]::Empty
+        if (-not [Guid]::TryParse($UuidMatch.Groups[1].Value, [ref]$GuidValue)) {
+            throw 'thread_invalid'
+        }
+
+        [void]$Candidates.Add($GuidValue.ToString('D').ToLowerInvariant())
+    }
+
+    if ($Candidates.Count -eq 0) {
+        throw 'thread_invalid'
+    }
+
+    if ($Candidates.Count -gt 1) {
+        throw 'thread_ambiguous'
+    }
+
+    foreach ($Candidate in $Candidates) {
+        return $Candidate
+    }
+
+    throw 'thread_invalid'
+}
+
+function Assert-NotificationMessage {
+    <#
+    .SYNOPSIS
+    Validates an explicit or default notification message.
+
+    .PARAMETER Message
+    The literal message to validate.
+
+    .OUTPUTS
+    System.String. Returns the unchanged message after validation.
+
+    .NOTES
+    The validation rejects line breaks, controls, invalid Unicode, edge
+    whitespace, and messages over 256 UTF-8 bytes without echoing the value.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Message
+    )
+
+    if ([string]::IsNullOrEmpty($Message) -or [string]::IsNullOrWhiteSpace($Message)) {
+        throw 'message_invalid'
+    }
+
+    if ([char]::IsWhiteSpace($Message[0]) -or [char]::IsWhiteSpace($Message[$Message.Length - 1])) {
+        throw 'message_invalid'
+    }
+
+    for ($CharacterIndex = 0; $CharacterIndex -lt $Message.Length; $CharacterIndex++) {
+        $Character = $Message[$CharacterIndex]
+        $CodePoint = [int][char]$Character
+
+        if ($CodePoint -eq 0x2028 -or $CodePoint -eq 0x2029) {
+            throw 'message_invalid'
+        }
+
+        if ([char]::IsHighSurrogate($Character)) {
+            if ($CharacterIndex + 1 -ge $Message.Length -or -not [char]::IsLowSurrogate($Message[$CharacterIndex + 1])) {
+                throw 'message_invalid'
+            }
+
+            $CharacterIndex++
+            continue
+        }
+
+        if ([char]::IsLowSurrogate($Character) -or [char]::IsControl($Character)) {
+            throw 'message_invalid'
+        }
+    }
+
+    try {
+        $Utf8Encoding = [Text.UTF8Encoding]::new($false, $true)
+        $Utf8Bytes = $Utf8Encoding.GetBytes($Message)
+    }
+    catch {
+        throw 'message_invalid'
+    }
+
+    if ($Utf8Bytes.Length -gt 256) {
+        throw 'message_invalid'
+    }
+
+    return $Message
+}
+
+function Initialize-StateDirectories {
+    <#
+    .SYNOPSIS
+    Creates the runtime directories under the resolved Codex home.
+
+    .OUTPUTS
+    None. Directory creation is a local side effect.
+    #>
+    if ([string]::IsNullOrWhiteSpace($CodexHome) -or
+        -not (Test-Path -LiteralPath $CodexHome -PathType Container)) {
+        throw 'codex_home_invalid'
+    }
+
+    foreach ($DirectoryPath in @($StateDirectory, $RequestDirectory, $LockDirectory, $CheckpointDirectory, $TerminalDirectory)) {
+        New-Item -ItemType Directory -Force -Path $DirectoryPath | Out-Null
+    }
+}
+
+function Get-RequestPath {
+    <#
+    .SYNOPSIS
+    Builds the active request path for a normalized thread UUID.
+
+    .PARAMETER ThreadId
+    A normalized lowercase UUID.
+
+    .OUTPUTS
+    System.String. Returns the request JSON path.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId
+    )
+
+    return (Join-Path $RequestDirectory "$ThreadId.json")
+}
+
+function Get-TerminalPath {
+    <#
+    .SYNOPSIS
+    Builds the latest terminal-result path for a normalized thread UUID.
+
+    .PARAMETER ThreadId
+    A normalized lowercase UUID.
+
+    .OUTPUTS
+    System.String. Returns the terminal result JSON path.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId
+    )
+
+    return (Join-Path $TerminalDirectory "$ThreadId.json")
+}
+
+function Get-LockPath {
+    <#
+    .SYNOPSIS
+    Builds the per-thread lock path.
+
+    .PARAMETER ThreadId
+    A normalized lowercase UUID.
+
+    .OUTPUTS
+    System.String. Returns the lock path.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId
+    )
+
+    return (Join-Path $LockDirectory "$ThreadId.lock")
+}
+
+function Get-CheckpointPath {
+    <#
+    .SYNOPSIS
+    Builds the fallback-watcher checkpoint path for a normalized thread UUID.
+
+    .PARAMETER ThreadId
+    A normalized lowercase UUID.
+
+    .OUTPUTS
+    System.String. Returns the checkpoint JSON path.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId
+    )
+
+    return (Join-Path $CheckpointDirectory "$ThreadId.json")
+}
+
+function Enter-CoordinationLock {
+    <#
+    .SYNOPSIS
+    Acquires the short-lived lock shared by arm and watcher shutdown checks.
+
+    .PARAMETER TimeoutMilliseconds
+    Maximum time to wait for the coordination lock.
+
+    .OUTPUTS
+    System.IO.FileStream. Returns an exclusive stream, or null on timeout.
+
+    .NOTES
+    The caller must dispose the stream. The watcher closes its lifetime lock
+    while holding this lock before exiting, so arm cannot lose a wake-up.
+    #>
+    param(
+        [ValidateRange(0, 120000)]
+        [int]$TimeoutMilliseconds = 10000
+    )
+
+    $Stopwatch = [Diagnostics.Stopwatch]::StartNew()
+    while ($Stopwatch.ElapsedMilliseconds -le $TimeoutMilliseconds) {
+        try {
+            return [IO.File]::Open(
+                $CoordinationLockPath,
+                [IO.FileMode]::OpenOrCreate,
+                [IO.FileAccess]::ReadWrite,
+                [IO.FileShare]::None
+            )
+        }
+        catch [IO.IOException] {
+            Start-Sleep -Milliseconds 50
+        }
+        catch {
+            return $null
+        }
+    }
+
+    return $null
+}
+
+function Enter-ThreadLock {
+    <#
+    .SYNOPSIS
+    Acquires a Windows OS-lifetime exclusive lock for one thread.
+
+    .PARAMETER ThreadId
+    A normalized lowercase UUID.
+
+    .PARAMETER TimeoutMilliseconds
+    Maximum time to wait for another helper to release the lock.
+
+    .OUTPUTS
+    System.IO.FileStream. Returns an exclusive stream, or null on timeout.
+
+    .NOTES
+    The caller must dispose the returned stream. The open handle, not the
+    marker file's existence, is the ownership proof.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId,
+
+        [ValidateRange(0, 120000)]
+        [int]$TimeoutMilliseconds = 10000
+    )
+
+    $LockPath = Get-LockPath -ThreadId $ThreadId
+    $Stopwatch = [Diagnostics.Stopwatch]::StartNew()
+
+    while ($Stopwatch.ElapsedMilliseconds -le $TimeoutMilliseconds) {
+        try {
+            return [IO.File]::Open(
+                $LockPath,
+                [IO.FileMode]::OpenOrCreate,
+                [IO.FileAccess]::ReadWrite,
+                [IO.FileShare]::None
+            )
+        }
+        catch [IO.IOException] {
+            Start-Sleep -Milliseconds 50
+        }
+        catch {
+            return $null
+        }
+    }
+
+    return $null
+}
+
+function Read-JsonDocument {
+    <#
+    .SYNOPSIS
+    Reads one local JSON document without exposing its contents.
+
+    .PARAMETER Path
+    The local JSON path to read.
+
+    .OUTPUTS
+    System.Object. Returns the parsed document, or null if the file is absent.
+
+    .NOTES
+    Parse failures are reported as a generic state error without the path.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        return (Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json)
+    }
+    catch {
+        throw 'state_invalid'
+    }
+}
+
+function Write-AtomicJsonDocument {
+    <#
+    .SYNOPSIS
+    Publishes a JSON document atomically within its destination directory.
+
+    .PARAMETER Path
+    The destination JSON path.
+
+    .PARAMETER Document
+    The object to serialize.
+
+    .OUTPUTS
+    None. The destination is replaced atomically on success.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [object]$Document
+    )
+
+    $DirectoryPath = Split-Path -Parent $Path
+    $FileName = Split-Path -Leaf $Path
+    $TemporaryPath = Join-Path $DirectoryPath ".${FileName}.$([Guid]::NewGuid().ToString('N')).tmp"
+    $BackupPath = Join-Path $DirectoryPath ".${FileName}.$([Guid]::NewGuid().ToString('N')).bak"
+
+    try {
+        $JsonText = $Document | ConvertTo-Json -Depth 20 -Compress
+        $Utf8Encoding = [Text.UTF8Encoding]::new($false)
+        [IO.File]::WriteAllText($TemporaryPath, "$JsonText`n", $Utf8Encoding)
+
+        if (Test-Path -LiteralPath $Path -PathType Leaf) {
+            [IO.File]::Replace($TemporaryPath, $Path, $BackupPath, $true)
+            Remove-Item -LiteralPath $BackupPath -Force -ErrorAction SilentlyContinue
+        }
+        else {
+            [IO.File]::Move($TemporaryPath, $Path)
+        }
+    }
+    catch {
+        throw 'state_write_failed'
+    }
+    finally {
+        if (Test-Path -LiteralPath $TemporaryPath -PathType Leaf) {
+            Remove-Item -LiteralPath $TemporaryPath -Force -ErrorAction SilentlyContinue
+        }
+        if (Test-Path -LiteralPath $BackupPath -PathType Leaf) {
+            Remove-Item -LiteralPath $BackupPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Remove-ActiveRequest {
+    <#
+    .SYNOPSIS
+    Removes an active request after its terminal result is recorded.
+
+    .PARAMETER ThreadId
+    A normalized lowercase UUID.
+
+    .OUTPUTS
+    System.Boolean. Returns true when the request is absent after the call.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId
+    )
+
+    $RequestPath = Get-RequestPath -ThreadId $ThreadId
+    if (-not (Test-Path -LiteralPath $RequestPath -PathType Leaf)) {
+        return $true
+    }
+
+    try {
+        Remove-Item -LiteralPath $RequestPath -Force -ErrorAction Stop
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+function Get-CodexSessionsDirectory {
+    <#
+    .SYNOPSIS
+    Resolves the local Codex sessions directory for the fallback watcher.
+
+    .OUTPUTS
+    System.String. Returns the sessions path without exposing it in diagnostics.
+
+    .NOTES
+    The path is derived from the process-lifetime home resolution used by all
+    state operations, so state and transcript detection cannot diverge.
+    #>
+    if ([string]::IsNullOrWhiteSpace($CodexHome)) {
+        return $null
+    }
+
+    return (Join-Path $CodexHome 'sessions')
+}
+
+function Test-PathWithinDirectory {
+    <#
+    .SYNOPSIS
+    Confirms that a path resolves beneath a specified directory.
+
+    .PARAMETER Path
+    The candidate path to validate.
+
+    .PARAMETER Directory
+    The directory that must contain the candidate path.
+
+    .OUTPUTS
+    System.Boolean. Returns true only for a descendant path under the
+    specified directory.
+
+    .NOTES
+    The comparison is lexical and case-insensitive for Windows paths. The
+    caller must still require the expected file type before reading the path.
+    #>
+    param(
+        [AllowNull()]
+        [string]$Path,
+
+        [AllowNull()]
+        [string]$Directory
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or [string]::IsNullOrWhiteSpace($Directory)) {
+        return $false
+    }
+
+    try {
+        $ResolvedPath = [IO.Path]::GetFullPath($Path)
+        $ResolvedDirectory = [IO.Path]::GetFullPath($Directory)
+        $RelativePath = [IO.Path]::GetRelativePath($ResolvedDirectory, $ResolvedPath)
+    }
+    catch {
+        return $false
+    }
+
+    if ([IO.Path]::IsPathRooted($RelativePath) -or $RelativePath -eq '.') {
+        return $false
+    }
+
+    return ($RelativePath -notmatch '^\.\.(?:[\\/]|$)')
+}
+
+function Get-LastCompleteLineOffset {
+    <#
+    .SYNOPSIS
+    Finds the byte offset immediately after the last complete JSONL line.
+
+    .PARAMETER Path
+    The rollout file to inspect.
+
+    .OUTPUTS
+    System.Int64. Returns zero for an absent or line-less file.
+
+    .NOTES
+    The fallback watcher never begins in the middle of a partial UTF-8 line.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $Stream = $null
+    try {
+        if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+            return 0L
+        }
+
+        $Stream = [IO.File]::Open(
+            $Path,
+            [IO.FileMode]::Open,
+            [IO.FileAccess]::Read,
+            [IO.FileShare]::ReadWrite
+        )
+        $Position = $Stream.Length
+        $Buffer = [byte[]]::new(4096)
+        while ($Position -gt 0) {
+            $ReadStart = [Math]::Max(0L, $Position - $Buffer.Length)
+            [void]$Stream.Seek($ReadStart, [IO.SeekOrigin]::Begin)
+            $ReadLength = [int]($Position - $ReadStart)
+            $ReadCount = $Stream.Read($Buffer, 0, $ReadLength)
+            for ($Index = $ReadCount - 1; $Index -ge 0; $Index--) {
+                if ($Buffer[$Index] -eq 0x0A) {
+                    return ($ReadStart + $Index + 1)
+                }
+            }
+            $Position = $ReadStart
+        }
+
+        return 0L
+    }
+    catch {
+        return 0L
+    }
+    finally {
+        if ($null -ne $Stream) {
+            $Stream.Dispose()
+        }
+    }
+}
+
+function New-ArmCheckpoint {
+    <#
+    .SYNOPSIS
+    Captures append offsets for rollout files that exist when a request is armed.
+
+    .PARAMETER ThreadId
+    The normalized target UUID.
+
+    .PARAMETER ArmedAtUtc
+    The UTC timestamp assigned to the new active request.
+
+    .PARAMETER Generation
+    The generation identifier assigned to the new active request.
+
+    .OUTPUTS
+    PSCustomObject. Returns a checkpoint document for the JSONL fallback.
+
+    .NOTES
+    Existing files start immediately after their last complete newline; newly
+    created files start at zero. The watcher still verifies session metadata and
+    event timestamps.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId,
+
+        [Parameter(Mandatory)]
+        [string]$ArmedAtUtc,
+
+        [Parameter(Mandatory)]
+        [string]$Generation
+    )
+
+    $FileEntries = @(
+        try {
+            $SessionsDirectory = Get-CodexSessionsDirectory
+            if (Test-Path -LiteralPath $SessionsDirectory -PathType Container) {
+                Get-ChildItem -LiteralPath $SessionsDirectory -Recurse -File -Filter 'rollout-*.jsonl' -ErrorAction SilentlyContinue |
+                    ForEach-Object {
+                        [ordered]@{
+                            path = $_.FullName
+                            offset = Get-LastCompleteLineOffset -Path $_.FullName
+                        }
+                    }
+            }
+        }
+        catch {
+            # An unavailable sessions directory is represented by an empty baseline.
+        }
+    )
+
+    return [ordered]@{
+        schemaVersion = 1
+        provider = 'codex'
+        generation = $Generation
+        target = [ordered]@{
+            threadId = $ThreadId
+        }
+        armedAtUtc = $ArmedAtUtc
+        files = $FileEntries
+    }
+}
+
+function Remove-Checkpoint {
+    <#
+    .SYNOPSIS
+    Removes a consumed fallback-watcher checkpoint.
+
+    .PARAMETER ThreadId
+    A normalized lowercase UUID.
+
+    .OUTPUTS
+    System.Boolean. Returns true when the checkpoint is absent after the call.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId
+    )
+
+    $CheckpointPath = Get-CheckpointPath -ThreadId $ThreadId
+    if (-not (Test-Path -LiteralPath $CheckpointPath -PathType Leaf)) {
+        return $true
+    }
+
+    try {
+        Remove-Item -LiteralPath $CheckpointPath -Force -ErrorAction Stop
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+function Test-WatcherRunning {
+    <#
+    .SYNOPSIS
+    Probes whether another fallback watcher owns the lifetime lock.
+
+    .OUTPUTS
+    System.Boolean. Returns true when the lock is currently held by another
+    process.
+    #>
+    $ProbeStream = $null
+    try {
+        $ProbeStream = [IO.File]::Open(
+            $WatcherLockPath,
+            [IO.FileMode]::OpenOrCreate,
+            [IO.FileAccess]::ReadWrite,
+            [IO.FileShare]::None
+        )
+        return $false
+    }
+    catch [IO.IOException] {
+        return $true
+    }
+    catch {
+        return $true
+    }
+    finally {
+        if ($null -ne $ProbeStream) {
+            $ProbeStream.Dispose()
+        }
+    }
+}
+
+function Start-FallbackWatcher {
+    <#
+    .SYNOPSIS
+    Starts the JSONL fallback watcher when fallback mode is explicitly enabled.
+
+    .OUTPUTS
+    None. The detached detector inherits the environment but receives no
+    notification content in its command line.
+
+    .NOTES
+    Set `TASK_COMPLETE_NOTIFY_WATCHER=1` only after the Stop-hook canary fails.
+    The watcher itself owns an OS-lifetime lock and exits when no requests remain.
+    #>
+    $FallbackEnabled = [Environment]::GetEnvironmentVariable('TASK_COMPLETE_NOTIFY_WATCHER', 'Process')
+    if ($FallbackEnabled -ne '1') {
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $WatcherScriptPath -PathType Leaf)) {
+        return
+    }
+
+    if (Test-WatcherRunning) {
+        return
+    }
+
+    $PowerShellExecutable = Join-Path $PSHOME 'pwsh.exe'
+    if (-not (Test-Path -LiteralPath $PowerShellExecutable -PathType Leaf)) {
+        return
+    }
+
+    $PreviousConfiguredCodexHome = [Environment]::GetEnvironmentVariable('CODEX_HOME', 'Process')
+    try {
+        # Normalize the child environment so a relative CODEX_HOME resolves to
+        # the same home even though the detached watcher changes its cwd.
+        [Environment]::SetEnvironmentVariable('CODEX_HOME', $CodexHome, 'Process')
+        Start-Process -FilePath $PowerShellExecutable `
+            -WindowStyle Hidden `
+            -WorkingDirectory $ScriptDirectory `
+            -ArgumentList @(
+                '-NoProfile',
+                '-NonInteractive',
+                '-File',
+                $WatcherScriptPath
+            ) | Out-Null
+    }
+    catch {
+        # Detector startup is best effort; arm remains a valid state operation.
+    }
+    finally {
+        [Environment]::SetEnvironmentVariable('CODEX_HOME', $PreviousConfiguredCodexHome, 'Process')
+    }
+}
+
+function Get-SafeTurnId {
+    <#
+    .SYNOPSIS
+    Normalizes a hook turn identifier for a terminal record.
+
+    .PARAMETER InputValue
+    An optional turn identifier from hook input.
+
+    .OUTPUTS
+    System.String. Returns a lowercase UUID or the fixed value `unknown`.
+    #>
+    param(
+        [AllowNull()]
+        [object]$InputValue
+    )
+
+    $TextValue = if ($null -eq $InputValue) { '' } else { [string]$InputValue }
+    if ($TextValue -match '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') {
+        return $TextValue.ToLowerInvariant()
+    }
+
+    return 'unknown'
+}
+
+function Write-TerminalResult {
+    <#
+    .SYNOPSIS
+    Writes a minimal terminal result that contains no message or topic.
+
+    .PARAMETER ThreadId
+    A normalized lowercase UUID.
+
+    .PARAMETER State
+    The active or attempting state whose identity is being finalized.
+
+    .PARAMETER Status
+    One of `success`, `failure`, or `abandoned`.
+
+    .PARAMETER TurnId
+    The sanitized turn UUID or `unknown`.
+
+    .OUTPUTS
+    None. The latest terminal result is atomically published.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId,
+
+        [Parameter(Mandatory)]
+        [object]$State,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('success', 'failure', 'abandoned')]
+        [string]$Status,
+
+        [Parameter(Mandatory)]
+        [string]$TurnId
+    )
+
+    $Generation = [string](Get-ObjectPropertyValue -InputObject $State -PropertyName 'generation')
+    $TerminalDocument = [ordered]@{
+        schemaVersion = 1
+        provider = 'codex'
+        generation = $Generation
+        target = [ordered]@{
+            threadId = $ThreadId
+        }
+        event = [ordered]@{
+            turnId = $TurnId
+        }
+        status = $Status
+        recordedAtUtc = [DateTimeOffset]::UtcNow.ToString('o')
+    }
+
+    Write-AtomicJsonDocument -Path (Get-TerminalPath -ThreadId $ThreadId) -Document $TerminalDocument
+}
+
+function Invoke-NotificationScript {
+    <#
+    .SYNOPSIS
+    Performs exactly one message-body notification attempt via notify.ps1.
+
+    .PARAMETER Message
+    The already validated message body.
+
+    .OUTPUTS
+    PSCustomObject. Returns only `Ok` and a generic `Reason`.
+
+    .NOTES
+    The message is sent through child-process stdin, never through arguments.
+    This function performs no retry and never returns topic or response data.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Message
+    )
+
+    try {
+        $PowerShellExecutable = Join-Path $PSHOME 'pwsh.exe'
+        if (-not (Test-Path -LiteralPath $PowerShellExecutable -PathType Leaf)) {
+            return [pscustomobject]@{
+                Ok = $false
+                Reason = 'transport_failure'
+            }
+        }
+
+        $RequestJson = [ordered]@{
+            message = $Message
+        } | ConvertTo-Json -Compress
+
+        $StartInfo = [Diagnostics.ProcessStartInfo]::new()
+        $StartInfo.FileName = $PowerShellExecutable
+        $StartInfo.UseShellExecute = $false
+        $StartInfo.CreateNoWindow = $true
+        $StartInfo.RedirectStandardInput = $true
+        $StartInfo.RedirectStandardOutput = $true
+        $StartInfo.RedirectStandardError = $true
+        $StartInfo.StandardInputEncoding = [Text.UTF8Encoding]::new($false)
+        $StartInfo.StandardOutputEncoding = [Text.UTF8Encoding]::new($false)
+        $StartInfo.StandardErrorEncoding = [Text.UTF8Encoding]::new($false)
+        [void]$StartInfo.ArgumentList.Add('-NoProfile')
+        [void]$StartInfo.ArgumentList.Add('-NonInteractive')
+        [void]$StartInfo.ArgumentList.Add('-File')
+        [void]$StartInfo.ArgumentList.Add($NotifyScriptPath)
+
+        $NotifierProcess = [Diagnostics.Process]::new()
+        try {
+            $NotifierProcess.StartInfo = $StartInfo
+            if (-not $NotifierProcess.Start()) {
+                return [pscustomobject]@{
+                    Ok = $false
+                    Reason = 'transport_failure'
+                }
+            }
+
+            $OutputTask = $NotifierProcess.StandardOutput.ReadToEndAsync()
+            $ErrorTask = $NotifierProcess.StandardError.ReadToEndAsync()
+            $NotifierProcess.StandardInput.Write($RequestJson)
+            $NotifierProcess.StandardInput.Close()
+            if (-not $NotifierProcess.WaitForExit(30000)) {
+                try {
+                    $NotifierProcess.Kill($true)
+                }
+                catch {
+                    # The notifier is already terminating; the attempt is terminal.
+                }
+                return [pscustomobject]@{
+                    Ok = $false
+                    Reason = 'transport_failure'
+                }
+            }
+
+            $NotifierOutput = $OutputTask.GetAwaiter().GetResult()
+            [void]$ErrorTask.GetAwaiter().GetResult()
+            if ($NotifierProcess.ExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($NotifierOutput)) {
+                return [pscustomobject]@{
+                    Ok = $false
+                    Reason = 'transport_failure'
+                }
+            }
+
+            $NotifierResult = $NotifierOutput | ConvertFrom-Json
+        }
+        finally {
+            $NotifierProcess.Dispose()
+        }
+
+        if ($NotifierResult.ok -eq $true) {
+            return [pscustomobject]@{
+                Ok = $true
+                Reason = 'success'
+            }
+        }
+
+        return [pscustomobject]@{
+            Ok = $false
+            Reason = 'delivery_failure'
+        }
+    }
+    catch {
+        return [pscustomobject]@{
+            Ok = $false
+            Reason = 'transport_failure'
+        }
+    }
+}
+
+function Read-TranscriptFirstLine {
+    <#
+    .SYNOPSIS
+    Reads only the first line of a Codex transcript for metadata validation.
+
+    .PARAMETER TranscriptPath
+    The transcript path supplied by the Stop hook.
+
+    .OUTPUTS
+    System.String. Returns the first line, or null when it cannot be read.
+
+    .NOTES
+    The line is parsed in memory and never emitted to output or state.
+    #>
+    param(
+        [AllowNull()]
+        [string]$TranscriptPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($TranscriptPath) -or -not (Test-Path -LiteralPath $TranscriptPath -PathType Leaf)) {
+        return $null
+    }
+
+    $TranscriptStream = $null
+    $TranscriptReader = $null
+    try {
+        $TranscriptStream = [IO.File]::Open(
+            $TranscriptPath,
+            [IO.FileMode]::Open,
+            [IO.FileAccess]::Read,
+            [IO.FileShare]::ReadWrite
+        )
+        $TranscriptReader = [IO.StreamReader]::new(
+            $TranscriptStream,
+            [Text.UTF8Encoding]::new($false, $false),
+            $true,
+            4096,
+            $true
+        )
+        $FirstLine = $TranscriptReader.ReadLine()
+        if ($null -ne $FirstLine -and $FirstLine.Length -gt 1048576) {
+            return $null
+        }
+
+        return $FirstLine
+    }
+    catch {
+        return $null
+    }
+    finally {
+        if ($null -ne $TranscriptReader) {
+            $TranscriptReader.Dispose()
+        }
+        if ($null -ne $TranscriptStream) {
+            $TranscriptStream.Dispose()
+        }
+    }
+}
+
+function Test-CodexTranscriptMetadata {
+    <#
+    .SYNOPSIS
+    Validates the first metadata record for one local Codex rollout.
+
+    .PARAMETER TranscriptPath
+    The rollout path to inspect.
+
+    .PARAMETER SessionId
+    The normalized UUID that must identify the session.
+
+    .OUTPUTS
+    System.Boolean. Returns true only for a user-created root session whose
+    metadata identifiers match the requested UUID.
+
+    .NOTES
+    Only the first line is read. Parent fields, malformed IDs, and non-user
+    sources fail closed; transcript content is never emitted or persisted.
+    #>
+    param(
+        [AllowNull()]
+        [string]$TranscriptPath,
+
+        [Parameter(Mandatory)]
+        [string]$SessionId
+    )
+
+    $FirstLine = Read-TranscriptFirstLine -TranscriptPath $TranscriptPath
+    if ([string]::IsNullOrWhiteSpace($FirstLine)) {
+        return $false
+    }
+
+    try {
+        $MetadataRecord = $FirstLine | ConvertFrom-Json
+    }
+    catch {
+        return $false
+    }
+
+    if ([string](Get-ObjectPropertyValue -InputObject $MetadataRecord -PropertyName 'type') -ne 'session_meta') {
+        return $false
+    }
+
+    $MetadataPayload = Get-ObjectPropertyValue -InputObject $MetadataRecord -PropertyName 'payload'
+    if ($null -eq $MetadataPayload) {
+        return $false
+    }
+
+    $MetadataSessionId = $null
+    try {
+        $MetadataSessionId = Normalize-CodexThreadId -InputValue ([string](Get-ObjectPropertyValue -InputObject $MetadataPayload -PropertyName 'session_id'))
+    }
+    catch {
+        return $false
+    }
+
+    $MetadataId = $null
+    try {
+        $MetadataId = Normalize-CodexThreadId -InputValue ([string](Get-ObjectPropertyValue -InputObject $MetadataPayload -PropertyName 'id'))
+    }
+    catch {
+        return $false
+    }
+
+    if ($MetadataSessionId -ne $SessionId -or $MetadataId -ne $SessionId) {
+        return $false
+    }
+
+    if ([string](Get-ObjectPropertyValue -InputObject $MetadataPayload -PropertyName 'thread_source') -ne 'user') {
+        return $false
+    }
+
+    foreach ($Property in $MetadataPayload.PSObject.Properties) {
+        if ($Property.Name -match '^parent' -and -not [string]::IsNullOrWhiteSpace([string]$Property.Value)) {
+            return $false
+        }
+    }
+
+    return $true
+}
+
+function Test-CodexSessionMetadata {
+    <#
+    .SYNOPSIS
+    Confirms that Stop input belongs to a user-created Codex session.
+
+    .PARAMETER HookInput
+    The parsed Stop-hook input object.
+
+    .PARAMETER SessionId
+    The normalized session UUID from hook input.
+
+    .OUTPUTS
+    System.Boolean. Returns true only when the first session_meta record matches.
+
+    .NOTES
+    Unknown, missing, or malformed metadata fails closed to prevent source
+    confusion with subagents, resumes, or guardian sessions.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$HookInput,
+
+        [Parameter(Mandatory)]
+        [string]$SessionId
+    )
+
+    $TranscriptPath = [string](Get-ObjectPropertyValue -InputObject $HookInput -PropertyName 'transcript_path')
+    $SessionsDirectory = Get-CodexSessionsDirectory
+    if (-not (Test-PathWithinDirectory -Path $TranscriptPath -Directory $SessionsDirectory)) {
+        return $false
+    }
+
+    return (Test-CodexTranscriptMetadata -TranscriptPath $TranscriptPath -SessionId $SessionId)
+}
+
+function Test-CodexSessionIndexContains {
+    <#
+    .SYNOPSIS
+    Checks whether the resolved Codex home indexes one target session.
+
+    .PARAMETER ThreadId
+    The normalized target UUID.
+
+    .OUTPUTS
+    System.Boolean. Returns true only for an exact `id` field match in the
+    local `session_index.jsonl` file.
+
+    .NOTES
+    Index records are a fast same-home candidate check; their names and values
+    are never logged. Transcript metadata remains the authoritative gate.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId
+    )
+
+    if ([string]::IsNullOrWhiteSpace($CodexHome) -or
+        -not (Test-Path -LiteralPath $CodexHome -PathType Container)) {
+        return $false
+    }
+
+    $IndexPath = Join-Path $CodexHome 'session_index.jsonl'
+    if (-not (Test-Path -LiteralPath $IndexPath -PathType Leaf)) {
+        return $false
+    }
+
+    try {
+        foreach ($Line in Get-Content -LiteralPath $IndexPath) {
+            if ([string]::IsNullOrWhiteSpace($Line)) {
+                continue
+            }
+
+            try {
+                $IndexRecord = $Line | ConvertFrom-Json
+                $IndexedId = Normalize-CodexThreadId -InputValue ([string](Get-ObjectPropertyValue -InputObject $IndexRecord -PropertyName 'id'))
+                if ($IndexedId -eq $ThreadId) {
+                    return $true
+                }
+            }
+            catch {
+                # Ignore malformed or unrelated index lines and keep scanning.
+            }
+        }
+    }
+    catch {
+        return $false
+    }
+
+    return $false
+}
+
+function Test-CodexThreadOwnership {
+    <#
+    .SYNOPSIS
+    Confirms that a target belongs to the current local Codex home.
+
+    .PARAMETER ThreadId
+    The normalized target UUID.
+
+    .OUTPUTS
+    System.Boolean. Returns true only when the local index and a matching
+    active rollout's root-session metadata both validate the target.
+
+    .NOTES
+    The check is performed before state directories are initialized. Archived
+    rollouts are not accepted because this notification targets a next active
+    completion. A filename match alone is never sufficient.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId
+    )
+
+    if (-not (Test-CodexSessionIndexContains -ThreadId $ThreadId)) {
+        return $false
+    }
+
+    $SessionsDirectory = Get-CodexSessionsDirectory
+    if ([string]::IsNullOrWhiteSpace($SessionsDirectory) -or
+        -not (Test-Path -LiteralPath $SessionsDirectory -PathType Container)) {
+        return $false
+    }
+
+    try {
+        $RolloutFiles = @(Get-ChildItem -LiteralPath $SessionsDirectory -Recurse -File -Filter "*-$ThreadId.jsonl" -ErrorAction SilentlyContinue)
+        foreach ($RolloutFile in $RolloutFiles) {
+            if (Test-CodexTranscriptMetadata -TranscriptPath $RolloutFile.FullName -SessionId $ThreadId) {
+                return $true
+            }
+        }
+    }
+    catch {
+        return $false
+    }
+
+    return $false
+}
+
+function New-ArmedState {
+    <#
+    .SYNOPSIS
+    Creates a versioned active request document for one generation.
+
+    .PARAMETER ThreadId
+    A normalized lowercase UUID.
+
+    .PARAMETER Message
+    The validated literal notification message.
+
+    .PARAMETER ArmedAtUtc
+    Optional timestamp used as the fallback-watcher baseline. When omitted,
+    the current UTC time is used.
+
+    .OUTPUTS
+    PSCustomObject. Returns the state document to publish atomically.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId,
+
+        [Parameter(Mandatory)]
+        [string]$Message,
+
+        [AllowNull()]
+        [string]$ArmedAtUtc
+    )
+
+    $EffectiveArmedAtUtc = if ([string]::IsNullOrWhiteSpace($ArmedAtUtc)) {
+        [DateTimeOffset]::UtcNow.ToString('o')
+    }
+    else {
+        $ArmedAtUtc
+    }
+
+    return [ordered]@{
+        schemaVersion = 1
+        provider = 'codex'
+        generation = ([Guid]::NewGuid().ToString('D').ToLowerInvariant())
+        status = 'armed'
+        target = [ordered]@{
+            threadId = $ThreadId
+        }
+        notification = [ordered]@{
+            message = $Message
+        }
+        armedAtUtc = $EffectiveArmedAtUtc
+    }
+}
+
+function New-AttemptingState {
+    <#
+    .SYNOPSIS
+    Creates the pre-send claim document without message content.
+
+    .PARAMETER ThreadId
+    A normalized lowercase UUID.
+
+    .PARAMETER State
+    The armed state being claimed.
+
+    .PARAMETER TurnId
+    The sanitized completion turn UUID.
+
+    .OUTPUTS
+    PSCustomObject. Returns the attempting state document.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId,
+
+        [Parameter(Mandatory)]
+        [object]$State,
+
+        [Parameter(Mandatory)]
+        [string]$TurnId
+    )
+
+    return [ordered]@{
+        schemaVersion = 1
+        provider = 'codex'
+        generation = [string](Get-ObjectPropertyValue -InputObject $State -PropertyName 'generation')
+        status = 'attempting'
+        target = [ordered]@{
+            threadId = $ThreadId
+        }
+        event = [ordered]@{
+            turnId = $TurnId
+        }
+        claimedAtUtc = [DateTimeOffset]::UtcNow.ToString('o')
+    }
+}
+
+function Invoke-ArmOperation {
+    <#
+    .SYNOPSIS
+    Registers one idempotent notification request under the thread lock.
+
+    .PARAMETER Request
+    The parsed arm envelope containing `thread` and optional `message`.
+
+    .OUTPUTS
+    PSCustomObject. Returns a sanitized operation result.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$Request
+    )
+
+    $CoordinationStream = $null
+    $LockStream = $null
+    try {
+        $ThreadId = Extract-ArmThreadId -InputValue ([string](Get-ObjectPropertyValue -InputObject $Request -PropertyName 'thread'))
+        $MessageProperty = Get-ObjectPropertyValue -InputObject $Request -PropertyName 'message'
+        $Message = if ($null -eq $MessageProperty) { 'Task completed' } else { [string]$MessageProperty }
+        [void](Assert-NotificationMessage -Message $Message)
+
+        # Refuse unknown or foreign-home IDs before creating any notification
+        # state. The resolved home is selected only from this process's env.
+        if (-not (Test-CodexThreadOwnership -ThreadId $ThreadId)) {
+            return [pscustomobject]@{
+                Ok = $false
+                Status = 'thread_not_managed'
+            }
+        }
+
+        Initialize-StateDirectories
+
+        $CoordinationStream = Enter-CoordinationLock
+        if ($null -eq $CoordinationStream) {
+            return [pscustomobject]@{
+                Ok = $false
+                Status = 'busy'
+            }
+        }
+
+        $LockStream = Enter-ThreadLock -ThreadId $ThreadId
+        if ($null -eq $LockStream) {
+            return [pscustomobject]@{
+                Ok = $false
+                Status = 'busy'
+            }
+        }
+
+        try {
+            $RequestPath = Get-RequestPath -ThreadId $ThreadId
+            $ExistingState = Read-JsonDocument -Path $RequestPath
+            if ($null -ne $ExistingState) {
+                $ExistingStatus = [string](Get-ObjectPropertyValue -InputObject $ExistingState -PropertyName 'status')
+                if ($ExistingStatus -eq 'armed') {
+                    Start-FallbackWatcher
+                    return [pscustomobject]@{
+                        Ok = $true
+                        Status = 'already_armed'
+                    }
+                }
+
+                if ($ExistingStatus -eq 'attempting') {
+                    $ExistingTurnId = Get-SafeTurnId -InputValue (Get-ObjectPropertyValue -InputObject (Get-ObjectPropertyValue -InputObject $ExistingState -PropertyName 'event') -PropertyName 'turnId')
+                    Write-TerminalResult -ThreadId $ThreadId -State $ExistingState -Status 'abandoned' -TurnId $ExistingTurnId
+                    if (-not (Remove-ActiveRequest -ThreadId $ThreadId)) {
+                        return [pscustomobject]@{
+                            Ok = $false
+                            Status = 'state_error'
+                        }
+                    }
+                    [void](Remove-Checkpoint -ThreadId $ThreadId)
+                }
+                else {
+                    return [pscustomobject]@{
+                        Ok = $false
+                        Status = 'state_invalid'
+                    }
+                }
+            }
+
+            $InitialArmedAtUtc = [DateTimeOffset]::UtcNow.ToString('o')
+            $NewState = New-ArmedState `
+                -ThreadId $ThreadId `
+                -Message $Message `
+                -ArmedAtUtc $InitialArmedAtUtc
+            $Generation = [string](Get-ObjectPropertyValue -InputObject $NewState -PropertyName 'generation')
+            $Checkpoint = New-ArmCheckpoint `
+                -ThreadId $ThreadId `
+                -Generation $Generation `
+                -ArmedAtUtc $InitialArmedAtUtc
+            # Publish time is after the baseline scan; events observed before it
+            # are intentionally outside this generation's completion window.
+            $ArmedAtUtc = [DateTimeOffset]::UtcNow.ToString('o')
+            $NewState['armedAtUtc'] = $ArmedAtUtc
+            $Checkpoint['armedAtUtc'] = $ArmedAtUtc
+            $Checkpoint['generation'] = $Generation
+            Write-AtomicJsonDocument -Path (Get-CheckpointPath -ThreadId $ThreadId) -Document $Checkpoint
+            Write-AtomicJsonDocument -Path $RequestPath -Document $NewState
+            Start-FallbackWatcher
+            return [pscustomobject]@{
+                Ok = $true
+                Status = 'armed'
+            }
+        }
+        finally {
+            $LockStream.Dispose()
+        }
+    }
+    catch {
+        $FailureStatus = [string]$_.Exception.Message
+        if ($FailureStatus -in @('thread_invalid', 'thread_ambiguous', 'message_invalid', 'codex_home_invalid')) {
+            return [pscustomobject]@{
+                Ok = $false
+                Status = $FailureStatus
+            }
+        }
+
+        return [pscustomobject]@{
+            Ok = $false
+            Status = 'error'
+        }
+    }
+    finally {
+        if ($null -ne $CoordinationStream) {
+            $CoordinationStream.Dispose()
+        }
+    }
+}
+
+function Invoke-StopOperation {
+    <#
+    .SYNOPSIS
+    Claims and consumes one matching Codex Stop event.
+
+    .PARAMETER HookInput
+    The parsed Codex Stop-hook input object.
+
+    .OUTPUTS
+    PSCustomObject. Returns a sanitized result; the caller may discard it.
+
+    .NOTES
+    The operation never retries. Once `attempting` is atomically published,
+    every send outcome is terminal and later Stop events cannot resend it.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$HookInput
+    )
+
+    $Claimed = $false
+    $ClaimedState = $null
+    $ThreadId = $null
+    $TurnId = 'unknown'
+    $LockStream = $null
+
+    try {
+        if ([string](Get-ObjectPropertyValue -InputObject $HookInput -PropertyName 'hook_event_name') -ne 'Stop') {
+            return [pscustomobject]@{
+                Ok = $true
+                Handled = $false
+            }
+        }
+
+        $StopHookActive = Get-ObjectPropertyValue -InputObject $HookInput -PropertyName 'stop_hook_active'
+        if ($StopHookActive -isnot [bool]) {
+            return [pscustomobject]@{
+                Ok = $true
+                Handled = $false
+            }
+        }
+
+        if ($StopHookActive) {
+            return [pscustomobject]@{
+                Ok = $true
+                Handled = $false
+            }
+        }
+
+        $ThreadId = Normalize-CodexThreadId -InputValue ([string](Get-ObjectPropertyValue -InputObject $HookInput -PropertyName 'session_id'))
+        if (-not (Test-CodexSessionMetadata -HookInput $HookInput -SessionId $ThreadId)) {
+            return [pscustomobject]@{
+                Ok = $true
+                Handled = $false
+            }
+        }
+
+        $TurnId = Get-SafeTurnId -InputValue (Get-ObjectPropertyValue -InputObject $HookInput -PropertyName 'turn_id')
+        $RequestPath = Get-RequestPath -ThreadId $ThreadId
+        if (-not (Test-Path -LiteralPath $RequestPath -PathType Leaf)) {
+            # A normal unarmed Stop must not create a runtime directory. An
+            # arm racing immediately after this check will be observed by a
+            # later Stop event or by the fallback watcher.
+            return [pscustomobject]@{
+                Ok = $true
+                Handled = $false
+            }
+        }
+
+        Initialize-StateDirectories
+        $LockStream = Enter-ThreadLock -ThreadId $ThreadId
+        if ($null -eq $LockStream) {
+            return [pscustomobject]@{
+                Ok = $true
+                Handled = $false
+            }
+        }
+
+        $ArmedState = Read-JsonDocument -Path $RequestPath
+        if ($null -eq $ArmedState -or [string](Get-ObjectPropertyValue -InputObject $ArmedState -PropertyName 'status') -ne 'armed') {
+            return [pscustomobject]@{
+                Ok = $true
+                Handled = $false
+            }
+        }
+
+        $TargetObject = Get-ObjectPropertyValue -InputObject $ArmedState -PropertyName 'target'
+        if ([string](Get-ObjectPropertyValue -InputObject $TargetObject -PropertyName 'threadId') -ne $ThreadId) {
+            return [pscustomobject]@{
+                Ok = $true
+                Handled = $false
+            }
+        }
+
+        $ExpectedGeneration = [string](Get-ObjectPropertyValue -InputObject $HookInput -PropertyName 'expected_generation')
+        $ActualGeneration = [string](Get-ObjectPropertyValue -InputObject $ArmedState -PropertyName 'generation')
+        if (-not [string]::IsNullOrWhiteSpace($ExpectedGeneration) -and
+            $ExpectedGeneration -ne $ActualGeneration) {
+            return [pscustomobject]@{
+                Ok = $true
+                Handled = $false
+            }
+        }
+
+        $ClaimedState = New-AttemptingState -ThreadId $ThreadId -State $ArmedState -TurnId $TurnId
+        Write-AtomicJsonDocument -Path $RequestPath -Document $ClaimedState
+        $Claimed = $true
+
+        $NotificationObject = Get-ObjectPropertyValue -InputObject $ArmedState -PropertyName 'notification'
+        $Message = [string](Get-ObjectPropertyValue -InputObject $NotificationObject -PropertyName 'message')
+        $MessageIsValid = $true
+        try {
+            [void](Assert-NotificationMessage -Message $Message)
+        }
+        catch {
+            $MessageIsValid = $false
+        }
+
+        if ($MessageIsValid) {
+            $NotificationResult = Invoke-NotificationScript -Message $Message
+            $TerminalStatus = if ($NotificationResult.Ok -eq $true) { 'success' } else { 'failure' }
+        }
+        else {
+            $TerminalStatus = 'failure'
+        }
+
+        Write-TerminalResult -ThreadId $ThreadId -State $ClaimedState -Status $TerminalStatus -TurnId $TurnId
+        [void](Remove-ActiveRequest -ThreadId $ThreadId)
+        [void](Remove-Checkpoint -ThreadId $ThreadId)
+        return [pscustomobject]@{
+            Ok = $true
+            Handled = $true
+            Status = $TerminalStatus
+        }
+    }
+    catch {
+        if ($Claimed -and $null -ne $ClaimedState -and $null -ne $ThreadId) {
+            try {
+                Write-TerminalResult -ThreadId $ThreadId -State $ClaimedState -Status 'failure' -TurnId $TurnId
+                [void](Remove-ActiveRequest -ThreadId $ThreadId)
+                [void](Remove-Checkpoint -ThreadId $ThreadId)
+            }
+            catch {
+                # Keep the attempting claim if terminal publication itself fails.
+            }
+        }
+
+        return [pscustomobject]@{
+            Ok = $false
+            Handled = $Claimed
+        }
+    }
+    finally {
+        if ($null -ne $LockStream) {
+            $LockStream.Dispose()
+        }
+    }
+}
+
+function Invoke-HelperRequest {
+    <#
+    .SYNOPSIS
+    Dispatches one stdin JSON operation to the arm or Stop handler.
+
+    .PARAMETER Request
+    The parsed helper request envelope.
+
+    .OUTPUTS
+    PSCustomObject. Returns a sanitized result suitable for JSON output.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [object]$Request
+    )
+
+    $Operation = [string](Get-ObjectPropertyValue -InputObject $Request -PropertyName 'operation')
+    switch ($Operation) {
+        'arm' {
+            return (Invoke-ArmOperation -Request $Request)
+        }
+        'stop' {
+            $HookInput = Get-ObjectPropertyValue -InputObject $Request -PropertyName 'hook'
+            if ($null -eq $HookInput) {
+                return [pscustomobject]@{
+                    Ok = $false
+                    Status = 'request_invalid'
+                }
+            }
+
+            return (Invoke-StopOperation -HookInput $HookInput)
+        }
+        default {
+            return [pscustomobject]@{
+                Ok = $false
+                Status = 'request_invalid'
+            }
+        }
+    }
+}
+
+$HelperResult = $null
+try {
+    $RequestText = [Console]::In.ReadToEnd()
+    if ([string]::IsNullOrWhiteSpace($RequestText)) {
+        throw 'request_invalid'
+    }
+
+    $RequestObject = $RequestText | ConvertFrom-Json
+    $HelperResult = Invoke-HelperRequest -Request $RequestObject
+}
+catch {
+    $HelperResult = [pscustomobject]@{
+        Ok = $false
+        Status = 'request_invalid'
+    }
+}
+
+[Console]::Out.WriteLine(($HelperResult | ConvertTo-Json -Compress))

--- a/.agents/skills/task-complete-notify/tests/task-complete-notify.tests.ps1
+++ b/.agents/skills/task-complete-notify/tests/task-complete-notify.tests.ps1
@@ -6,7 +6,6 @@ param()
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
-[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
 
 $SkillDirectory = Split-Path -Parent $PSScriptRoot
 $ScriptDirectory = Join-Path $SkillDirectory 'scripts'
@@ -314,6 +313,31 @@ try {
         Assert-Condition ($Errors.Count -eq 0) "parser_$($ScriptFile.BaseName)"
     }
 
+    $StopHookText = Get-Content -Raw -LiteralPath (Join-Path $ScriptDirectory 'codex-stop-hook.ps1')
+    $ArmText = Get-Content -Raw -LiteralPath (Join-Path $ScriptDirectory 'arm-notification.ps1')
+    $NotifyText = Get-Content -Raw -LiteralPath (Join-Path $ScriptDirectory 'notify.ps1')
+    $HelperText = Get-Content -Raw -LiteralPath (Join-Path $ScriptDirectory 'windows-helper.ps1')
+    $WatcherText = Get-Content -Raw -LiteralPath (Join-Path $ScriptDirectory 'codex-watcher.ps1')
+    Assert-Condition (-not ($StopHookText -match '\[Console\]::InputEncoding')) 'stop_no_console_encoding_mutation'
+    Assert-Condition (-not ($ArmText -match '\[Console\]::InputEncoding')) 'arm_no_console_encoding_mutation'
+    Assert-Condition (-not ($NotifyText -match '\[Console\]::InputEncoding')) 'notify_no_console_encoding_mutation'
+    Assert-Condition (-not ($HelperText -match '\[Console\]::InputEncoding')) 'helper_no_console_encoding_mutation'
+    Assert-Condition (-not ($WatcherText -match '\[Console\]::InputEncoding')) 'watcher_no_console_encoding_mutation'
+    Assert-Condition ($StopHookText -match '\[Console\]::OpenStandardInput\(\)' -and
+        $NotifyText -match '\[Console\]::OpenStandardInput\(\)' -and
+        $HelperText -match '\[Console\]::OpenStandardInput\(\)') 'explicit_utf8_stdin_readers'
+    Assert-Condition ($StopHookText -match '\$HelperTimeoutMilliseconds\s*=\s*55000' -and
+        $StopHookText -match 'WaitForExit\(\$HelperTimeoutMilliseconds\)') 'stop_timeout_headroom'
+    Assert-Condition ($HelperText -match '\$NotifierTimeoutMilliseconds\s*=\s*35000' -and
+        $HelperText -match 'WaitForExit\(\$NotifierTimeoutMilliseconds\)' -and
+        $NotifyText -match '-ConnectionTimeoutSeconds\s+10' -and
+        $NotifyText -match '-OperationTimeoutSeconds\s+20' -and
+        $StopHookText -match '\$HelperTimeoutMilliseconds\s*=\s*55000' -and
+        (10000 + 35000 + 5000) -lt 55000 -and
+        55000 -lt 90000) 'notification_timeout_hierarchy'
+    Assert-Condition (-not ($WatcherText -match '\.task-complete-notify\.invalid') -and
+        -not ($HelperText -match '\.task-complete-notify\.invalid')) 'no_invalid_home_fallback_path'
+
     $NotifyPath = Join-Path $ScriptDirectory 'notify.ps1'
     $NotifyResult = Invoke-NativeWithInput -ScriptPath $NotifyPath -InputText '{"message":"Task completed"}'
     $NotifyJson = $NotifyResult.Stdout.Trim() | ConvertFrom-Json
@@ -323,6 +347,17 @@ try {
     $ArmPath = Join-Path $ScriptDirectory 'arm-notification.ps1'
     $StopPath = Join-Path $ScriptDirectory 'codex-stop-hook.ps1'
     $WatcherPath = Join-Path $ScriptDirectory 'codex-watcher.ps1'
+    $InvalidHomePath = Join-Path $SkillDirectory '.task-complete-notify.invalid'
+    $InvalidHomeValue = Join-Path $FixtureRoot 'missing-codex-home'
+    [Environment]::SetEnvironmentVariable('CODEX_HOME', $InvalidHomeValue, 'Process')
+    $InvalidHomeOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $TestId
+    $InvalidHomeJson = ($InvalidHomeOutput -join "`n") | ConvertFrom-Json
+    Assert-Condition ($LASTEXITCODE -ne 0 -and $InvalidHomeJson.Ok -eq $false) 'invalid_home_rejected'
+    Assert-Condition (-not (Test-Path -LiteralPath $InvalidHomePath -PathType Container)) 'invalid_home_no_skill_state'
+    $InvalidWatcherOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $WatcherPath -Once 2>$null
+    Assert-Condition ($LASTEXITCODE -ne 0) 'invalid_watcher_home_rejected'
+    Assert-Condition (-not (Test-Path -LiteralPath $InvalidHomePath -PathType Container)) 'invalid_watcher_no_skill_state'
+    [Environment]::SetEnvironmentVariable('CODEX_HOME', $FixtureRoot, 'Process')
     $StatePath = Join-Path $StateDirectory "requests\$TestId.json"
     $CheckpointPath = Join-Path $StateDirectory "checkpoints\$TestId.json"
     $TerminalPath = Join-Path $StateDirectory "terminal\$TestId.json"

--- a/.agents/skills/task-complete-notify/tests/task-complete-notify.tests.ps1
+++ b/.agents/skills/task-complete-notify/tests/task-complete-notify.tests.ps1
@@ -1,0 +1,721 @@
+#requires -Version 7.4
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+[Console]::InputEncoding = [Text.UTF8Encoding]::new($false)
+
+$SkillDirectory = Split-Path -Parent $PSScriptRoot
+$ScriptDirectory = Join-Path $SkillDirectory 'scripts'
+$PowerShellExecutable = Join-Path $PSHOME 'pwsh.exe'
+$TestId = [Guid]::NewGuid().ToString('D').ToLowerInvariant()
+$SecondTestId = [Guid]::NewGuid().ToString('D').ToLowerInvariant()
+$ThirdTestId = [Guid]::NewGuid().ToString('D').ToLowerInvariant()
+$FourthTestId = [Guid]::NewGuid().ToString('D').ToLowerInvariant()
+$StopActiveTestId = [Guid]::NewGuid().ToString('D').ToLowerInvariant()
+$ResidentTestId = [Guid]::NewGuid().ToString('D').ToLowerInvariant()
+$TransientTestId = [Guid]::NewGuid().ToString('D').ToLowerInvariant()
+$GenerationTestId = [Guid]::NewGuid().ToString('D').ToLowerInvariant()
+$NotHandledTestId = [Guid]::NewGuid().ToString('D').ToLowerInvariant()
+$FixtureRoot = Join-Path ([IO.Path]::GetTempPath()) "task-complete-notify-tests-$([Guid]::NewGuid().ToString('N'))"
+$StateDirectory = Join-Path $FixtureRoot '.task-complete-notify'
+$CreatedStatePaths = [Collections.Generic.List[string]]::new()
+$ResidentProcess = $null
+
+function Assert-Condition {
+    <#
+    .SYNOPSIS
+    Fails the test run when a required condition is false.
+
+    .PARAMETER Condition
+    The condition that must be true.
+
+    .PARAMETER Name
+    A fixed test identifier; it must not contain notification content.
+
+    .OUTPUTS
+    None. Throws a generic assertion error on failure.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [bool]$Condition,
+
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    if (-not $Condition) {
+        throw "assert_failed:$Name"
+    }
+}
+
+function Invoke-NativeWithInput {
+    <#
+    .SYNOPSIS
+    Runs a PowerShell script with UTF-8 JSON on standard input.
+
+    .PARAMETER ScriptPath
+    The script to execute.
+
+    .PARAMETER InputText
+    The JSON input sent only through standard input.
+
+    .PARAMETER Arguments
+    Additional non-secret script arguments.
+
+    .OUTPUTS
+    PSCustomObject. Returns exit code and captured output for assertions.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ScriptPath,
+
+        [Parameter(Mandatory)]
+        [string]$InputText,
+
+        [string[]]$Arguments = @()
+    )
+
+    $StartInfo = [Diagnostics.ProcessStartInfo]::new()
+    $StartInfo.FileName = $PowerShellExecutable
+    $StartInfo.UseShellExecute = $false
+    $StartInfo.CreateNoWindow = $true
+    $StartInfo.RedirectStandardInput = $true
+    $StartInfo.RedirectStandardOutput = $true
+    $StartInfo.RedirectStandardError = $true
+    $StartInfo.StandardInputEncoding = [Text.UTF8Encoding]::new($false)
+    $StartInfo.StandardOutputEncoding = [Text.UTF8Encoding]::new($false)
+    $StartInfo.StandardErrorEncoding = [Text.UTF8Encoding]::new($false)
+    [void]$StartInfo.ArgumentList.Add('-NoProfile')
+    [void]$StartInfo.ArgumentList.Add('-NonInteractive')
+    [void]$StartInfo.ArgumentList.Add('-File')
+    [void]$StartInfo.ArgumentList.Add($ScriptPath)
+    foreach ($Argument in $Arguments) {
+        [void]$StartInfo.ArgumentList.Add($Argument)
+    }
+
+    $Process = [Diagnostics.Process]::new()
+    try {
+        $Process.StartInfo = $StartInfo
+        if (-not $Process.Start()) {
+            throw 'process_start_failed'
+        }
+
+        $OutputTask = $Process.StandardOutput.ReadToEndAsync()
+        $ErrorTask = $Process.StandardError.ReadToEndAsync()
+        $Process.StandardInput.Write($InputText)
+        $Process.StandardInput.Close()
+        if (-not $Process.WaitForExit(60000)) {
+            try {
+                $Process.Kill($true)
+            }
+            catch {
+                # The test child is already terminating.
+            }
+            throw 'process_timeout'
+        }
+
+        return [pscustomobject]@{
+            ExitCode = $Process.ExitCode
+            Stdout = $OutputTask.GetAwaiter().GetResult()
+            Stderr = $ErrorTask.GetAwaiter().GetResult()
+        }
+    }
+    finally {
+        $Process.Dispose()
+    }
+}
+
+function Start-DetachedPowerShell {
+    <#
+    .SYNOPSIS
+    Starts a background PowerShell script for resident-watcher assertions.
+
+    .PARAMETER ScriptPath
+    The script to execute.
+
+    .PARAMETER Arguments
+    Non-secret script arguments.
+
+    .OUTPUTS
+    System.Diagnostics.Process. Returns the started process handle.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ScriptPath,
+
+        [string[]]$Arguments = @()
+    )
+
+    $StartInfo = [Diagnostics.ProcessStartInfo]::new()
+    $StartInfo.FileName = $PowerShellExecutable
+    $StartInfo.UseShellExecute = $false
+    $StartInfo.CreateNoWindow = $true
+    [void]$StartInfo.ArgumentList.Add('-NoProfile')
+    [void]$StartInfo.ArgumentList.Add('-NonInteractive')
+    [void]$StartInfo.ArgumentList.Add('-File')
+    [void]$StartInfo.ArgumentList.Add($ScriptPath)
+    foreach ($Argument in $Arguments) {
+        [void]$StartInfo.ArgumentList.Add($Argument)
+    }
+
+    $Process = [Diagnostics.Process]::new()
+    $Process.StartInfo = $StartInfo
+    if (-not $Process.Start()) {
+        $Process.Dispose()
+        throw 'process_start_failed'
+    }
+
+    return $Process
+}
+
+function Read-JsonFile {
+    <#
+    .SYNOPSIS
+    Reads a test JSON file for non-secret state assertions.
+
+    .PARAMETER Path
+    The explicit test-state path to read.
+
+    .OUTPUTS
+    System.Object. Returns the parsed JSON document.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    return (Get-Content -Raw -LiteralPath $Path | ConvertFrom-Json)
+}
+
+function New-TestTranscript {
+    <#
+    .SYNOPSIS
+    Creates a minimal Codex-style transcript fixture.
+
+    .PARAMETER Path
+    The explicit fixture path.
+
+    .PARAMETER ThreadId
+    The user session UUID to put in session_meta.
+
+    .PARAMETER IncludeOldComplete
+    Adds a task_complete record timestamped before arm.
+
+    .OUTPUTS
+    None. The fixture is written as UTF-8 JSONL.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [string]$ThreadId,
+
+        [switch]$IncludeOldComplete
+    )
+
+    $Lines = [Collections.Generic.List[string]]::new()
+    $Lines.Add((
+        [ordered]@{
+            timestamp = [DateTimeOffset]::UtcNow.ToString('o')
+            type = 'session_meta'
+            payload = [ordered]@{
+                id = $ThreadId
+                session_id = $ThreadId
+                thread_source = 'user'
+            }
+        } | ConvertTo-Json -Compress
+    ))
+
+    if ($IncludeOldComplete) {
+        $Lines.Add((
+            [ordered]@{
+                timestamp = [DateTimeOffset]::UtcNow.AddMinutes(-1).ToString('o')
+                type = 'event_msg'
+                payload = [ordered]@{
+                    type = 'task_complete'
+                    turn_id = $ThreadId
+                }
+            } | ConvertTo-Json -Compress
+        ))
+    }
+
+    [IO.File]::WriteAllText($Path, (($Lines -join "`n") + "`n"), [Text.UTF8Encoding]::new($false))
+}
+
+function Add-TestSessionIndexEntry {
+    <#
+    .SYNOPSIS
+    Appends a minimal local Codex session-index fixture entry.
+
+    .PARAMETER ThreadId
+    The UUID represented by the fixture rollout.
+
+    .PARAMETER CodexHomePath
+    Optional fixture Codex home; the main fixture home is used by default.
+
+    .OUTPUTS
+    None. The entry is appended to the explicit test Codex home index.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ThreadId,
+
+        [string]$CodexHomePath = $FixtureRoot
+    )
+
+    $IndexPath = Join-Path $CodexHomePath 'session_index.jsonl'
+    $Entry = [ordered]@{
+        id = $ThreadId
+        thread_name = 'fixture'
+        updated_at = [DateTimeOffset]::UtcNow.ToString('o')
+    } | ConvertTo-Json -Compress
+    [IO.File]::AppendAllText($IndexPath, "$Entry`n", [Text.UTF8Encoding]::new($false))
+}
+
+function Remove-TestState {
+    <#
+    .SYNOPSIS
+    Removes only the explicit state files created by this test run.
+
+    .OUTPUTS
+    None. Cleanup is limited to known generated paths.
+    #>
+    foreach ($Path in $CreatedStatePaths) {
+        Remove-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$OriginalNtfyTopic = [Environment]::GetEnvironmentVariable('NTFY_TOPIC', 'Process')
+$OriginalCodexHome = [Environment]::GetEnvironmentVariable('CODEX_HOME', 'Process')
+$OriginalWatcherMode = [Environment]::GetEnvironmentVariable('TASK_COMPLETE_NOTIFY_WATCHER', 'Process')
+
+try {
+    New-Item -ItemType Directory -Force -Path $FixtureRoot | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $FixtureRoot 'sessions\2026\01') | Out-Null
+    [Environment]::SetEnvironmentVariable('NTFY_TOPIC', $null, 'Process')
+    [Environment]::SetEnvironmentVariable('CODEX_HOME', $FixtureRoot, 'Process')
+    [Environment]::SetEnvironmentVariable('TASK_COMPLETE_NOTIFY_WATCHER', $null, 'Process')
+
+    foreach ($InitialThreadId in @($TestId, $SecondTestId, $ThirdTestId, $FourthTestId, $StopActiveTestId)) {
+        $InitialTranscriptPath = Join-Path $FixtureRoot "sessions\2026\01\rollout-2026-01-01T00-00-00-$InitialThreadId.jsonl"
+        New-TestTranscript -Path $InitialTranscriptPath -ThreadId $InitialThreadId
+        Add-TestSessionIndexEntry -ThreadId $InitialThreadId
+    }
+
+    foreach ($ScriptFile in Get-ChildItem -LiteralPath $ScriptDirectory -Filter '*.ps1' -File -Recurse) {
+        $Tokens = $null
+        $Errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile($ScriptFile.FullName, [ref]$Tokens, [ref]$Errors) | Out-Null
+        Assert-Condition ($Errors.Count -eq 0) "parser_$($ScriptFile.BaseName)"
+    }
+
+    $NotifyPath = Join-Path $ScriptDirectory 'notify.ps1'
+    $NotifyResult = Invoke-NativeWithInput -ScriptPath $NotifyPath -InputText '{"message":"Task completed"}'
+    $NotifyJson = $NotifyResult.Stdout.Trim() | ConvertFrom-Json
+    Assert-Condition ($NotifyJson.Ok -eq $false -and $NotifyJson.Reason -eq 'topic_missing') 'notify_missing_topic'
+    Assert-Condition ([string]::IsNullOrWhiteSpace($NotifyResult.Stderr)) 'notify_no_stderr'
+
+    $ArmPath = Join-Path $ScriptDirectory 'arm-notification.ps1'
+    $StopPath = Join-Path $ScriptDirectory 'codex-stop-hook.ps1'
+    $WatcherPath = Join-Path $ScriptDirectory 'codex-watcher.ps1'
+    $StatePath = Join-Path $StateDirectory "requests\$TestId.json"
+    $CheckpointPath = Join-Path $StateDirectory "checkpoints\$TestId.json"
+    $TerminalPath = Join-Path $StateDirectory "terminal\$TestId.json"
+    foreach ($Path in @($StatePath, $CheckpointPath, $TerminalPath, (Join-Path $StateDirectory "locks\$TestId.lock"))) {
+        [void]$CreatedStatePaths.Add($Path)
+    }
+
+    $ForeignId = [Guid]::NewGuid().ToString('D').ToLowerInvariant()
+    $ForeignOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $ForeignId
+    $ForeignJson = ($ForeignOutput -join "`n") | ConvertFrom-Json
+    Assert-Condition ($LASTEXITCODE -ne 0 -and $ForeignJson.Status -eq 'thread_not_managed') 'foreign_thread_rejected'
+    Assert-Condition (-not (Test-Path -LiteralPath $StateDirectory -PathType Container)) 'foreign_does_not_create_state'
+
+    $ArmOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread "対象: [thread](codex://threads/$TestId) / $TestId" -Message '初回本文'
+    $ArmExitCode = $LASTEXITCODE
+    $ArmJson = ($ArmOutput -join "`n") | ConvertFrom-Json
+    Assert-Condition ($ArmExitCode -eq 0 -and $ArmJson.Ok -eq $true -and $ArmJson.Status -eq 'armed') 'arm_explicit_message'
+    Assert-Condition ((Read-JsonFile -Path $StatePath).notification.message -eq '初回本文') 'arm_message_literal'
+    Assert-Condition (Test-Path -LiteralPath $CheckpointPath -PathType Leaf) 'arm_checkpoint'
+
+    $RearmOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $TestId -Message '上書き不可'
+    $RearmJson = ($RearmOutput -join "`n") | ConvertFrom-Json
+    Assert-Condition ($RearmJson.Ok -eq $true -and $RearmJson.Status -eq 'already_armed') 'rearm_idempotent'
+    Assert-Condition ((Read-JsonFile -Path $StatePath).notification.message -eq '初回本文') 'rearm_preserves_message'
+
+    $StopActiveStatePath = Join-Path $StateDirectory "requests\\$StopActiveTestId.json"
+    $StopActiveCheckpointPath = Join-Path $StateDirectory "checkpoints\\$StopActiveTestId.json"
+    $StopActiveTerminalPath = Join-Path $StateDirectory "terminal\\$StopActiveTestId.json"
+    foreach ($Path in @($StopActiveStatePath, $StopActiveCheckpointPath, $StopActiveTerminalPath, (Join-Path $StateDirectory "locks\\$StopActiveTestId.lock"))) {
+        [void]$CreatedStatePaths.Add($Path)
+    }
+    & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $StopActiveTestId -Message '停止hook再入' | Out-Null
+    Assert-Condition ($LASTEXITCODE -eq 0) 'stop_hook_active_arm'
+    $StopActiveTranscriptPath = Join-Path $FixtureRoot "sessions\2026\01\stop-active-$StopActiveTestId.jsonl"
+    New-TestTranscript -Path $StopActiveTranscriptPath -ThreadId $StopActiveTestId
+    $StopActiveInput = [ordered]@{
+        hook_event_name = 'Stop'
+        session_id = $StopActiveTestId
+        transcript_path = $StopActiveTranscriptPath
+        turn_id = $SecondTestId
+        stop_hook_active = $true
+    } | ConvertTo-Json -Compress
+    $StopActiveResult = Invoke-NativeWithInput -ScriptPath $StopPath -InputText $StopActiveInput
+    Assert-Condition ($StopActiveResult.ExitCode -eq 0 -and [string]::IsNullOrWhiteSpace($StopActiveResult.Stdout)) 'stop_hook_active_silent'
+    Assert-Condition ((Read-JsonFile -Path $StopActiveStatePath).status -eq 'armed') 'stop_hook_active_keeps_state'
+    Assert-Condition (-not (Test-Path -LiteralPath $StopActiveTerminalPath -PathType Leaf)) 'stop_hook_active_no_terminal'
+    # This request was intentionally preserved by the re-entry test; remove
+    # its fixture before starting the resident watcher scenario below.
+    Remove-Item -LiteralPath $StopActiveStatePath, $StopActiveCheckpointPath -Force -ErrorAction Stop
+
+    $PersonalCodexHome = Join-Path $FixtureRoot 'personal-home'
+    $PersonalSessionsDirectory = Join-Path $PersonalCodexHome 'sessions\2026\01'
+    New-Item -ItemType Directory -Force -Path $PersonalSessionsDirectory | Out-Null
+    $PersonalTranscriptPath = Join-Path $PersonalSessionsDirectory "rollout-2026-01-01T00-00-00-$TestId.jsonl"
+    New-TestTranscript -Path $PersonalTranscriptPath -ThreadId $TestId
+    Add-TestSessionIndexEntry -ThreadId $TestId -CodexHomePath $PersonalCodexHome
+    [Environment]::SetEnvironmentVariable('CODEX_HOME', $PersonalCodexHome, 'Process')
+    $PersonalStateDirectory = Join-Path $PersonalCodexHome '.task-complete-notify'
+    $PersonalStatePath = Join-Path $PersonalStateDirectory "requests\$TestId.json"
+    [void]$CreatedStatePaths.Add($PersonalStatePath)
+    $PersonalArmOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $TestId -Message 'personal home'
+    Assert-Condition ($LASTEXITCODE -eq 0) 'personal_home_arm'
+    Assert-Condition ((Read-JsonFile -Path $PersonalStatePath).notification.message -eq 'personal home') 'personal_home_state_isolated'
+    Assert-Condition ((Read-JsonFile -Path $StatePath).notification.message -eq '初回本文') 'default_home_state_preserved'
+    [Environment]::SetEnvironmentVariable('CODEX_HOME', $FixtureRoot, 'Process')
+
+    $AttemptingStatePath = Join-Path $StateDirectory "requests\$SecondTestId.json"
+    $AttemptingCheckpointPath = Join-Path $StateDirectory "checkpoints\$SecondTestId.json"
+    $AttemptingTerminalPath = Join-Path $StateDirectory "terminal\$SecondTestId.json"
+    foreach ($Path in @($AttemptingStatePath, $AttemptingCheckpointPath, $AttemptingTerminalPath, (Join-Path $StateDirectory "locks\$SecondTestId.lock"))) {
+        [void]$CreatedStatePaths.Add($Path)
+    }
+    $AttemptingArmOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $SecondTestId -Message '孤立予約'
+    Assert-Condition ($LASTEXITCODE -eq 0) 'attempting_arm'
+    $AttemptingState = Read-JsonFile -Path $AttemptingStatePath
+    $AttemptingStateDocument = [ordered]@{
+        schemaVersion = $AttemptingState.schemaVersion
+        provider = $AttemptingState.provider
+        generation = $AttemptingState.generation
+        status = 'attempting'
+        target = [ordered]@{ threadId = $SecondTestId }
+        event = [ordered]@{ turnId = $ThirdTestId }
+        claimedAtUtc = [DateTimeOffset]::UtcNow.ToString('o')
+    }
+    [IO.File]::WriteAllText($AttemptingStatePath, ($AttemptingStateDocument | ConvertTo-Json -Depth 20 -Compress), [Text.UTF8Encoding]::new($false))
+    $OrphanRearmOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $SecondTestId -Message '新世代'
+    $OrphanRearmJson = ($OrphanRearmOutput -join "`n") | ConvertFrom-Json
+    Assert-Condition ($LASTEXITCODE -eq 0 -and $OrphanRearmJson.Ok -eq $true -and $OrphanRearmJson.Status -eq 'armed') 'attempting_rearm'
+    Assert-Condition ((Read-JsonFile -Path $AttemptingTerminalPath).status -eq 'abandoned') 'attempting_abandoned'
+    Assert-Condition ((Read-JsonFile -Path $AttemptingStatePath).notification.message -eq '新世代') 'attempting_new_generation'
+    # The orphan-rearm case is complete; remove its deliberately retained
+    # active generation so later watcher tests have a single live request.
+    Remove-Item -LiteralPath $AttemptingStatePath, $AttemptingCheckpointPath -Force -ErrorAction Stop
+
+    $TranscriptPath = Join-Path $FixtureRoot "sessions\2026\01\stop-$TestId.jsonl"
+    New-TestTranscript -Path $TranscriptPath -ThreadId $TestId
+    $ExternalTranscriptPath = Join-Path $FixtureRoot "external-$TestId.jsonl"
+    New-TestTranscript -Path $ExternalTranscriptPath -ThreadId $TestId
+    $ExternalStopInput = [ordered]@{
+        hook_event_name = 'Stop'
+        session_id = $TestId
+        transcript_path = $ExternalTranscriptPath
+        turn_id = $SecondTestId
+        stop_hook_active = $false
+    } | ConvertTo-Json -Compress
+    $ExternalStopResult = Invoke-NativeWithInput -ScriptPath $StopPath -InputText $ExternalStopInput
+    Assert-Condition ($ExternalStopResult.ExitCode -eq 0 -and [string]::IsNullOrWhiteSpace($ExternalStopResult.Stdout)) 'stop_external_transcript_silent'
+    Assert-Condition (Test-Path -LiteralPath $StatePath -PathType Leaf) 'stop_external_transcript_keeps_active'
+    $StopInput = [ordered]@{
+        hook_event_name = 'Stop'
+        session_id = $TestId
+        transcript_path = $TranscriptPath
+        turn_id = $SecondTestId
+        stop_hook_active = $false
+    } | ConvertTo-Json -Compress
+    $StopResult = Invoke-NativeWithInput -ScriptPath $StopPath -InputText $StopInput
+    Assert-Condition ($StopResult.ExitCode -eq 0 -and [string]::IsNullOrWhiteSpace($StopResult.Stdout)) 'stop_silent_output'
+    Assert-Condition (-not (Test-Path -LiteralPath $StatePath -PathType Leaf)) 'stop_consumes_active'
+    Assert-Condition ((Read-JsonFile -Path $TerminalPath).status -eq 'failure') 'stop_terminal_failure'
+    $SecondStopResult = Invoke-NativeWithInput -ScriptPath $StopPath -InputText $StopInput
+    Assert-Condition ($SecondStopResult.ExitCode -eq 0 -and [string]::IsNullOrWhiteSpace($SecondStopResult.Stdout)) 'stop_no_resend'
+
+    $InvalidUriOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread "codex://$ThirdTestId"
+    $InvalidUriJson = ($InvalidUriOutput -join "`n") | ConvertFrom-Json
+    Assert-Condition ($LASTEXITCODE -ne 0 -and $InvalidUriJson.Ok -eq $false) 'legacy_uri_rejected'
+
+    $AmbiguousOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread "対象 $ThirdTestId と $FourthTestId"
+    $AmbiguousJson = ($AmbiguousOutput -join "`n") | ConvertFrom-Json
+    Assert-Condition ($LASTEXITCODE -ne 0 -and $AmbiguousJson.Status -eq 'thread_ambiguous') 'ambiguous_thread_rejected'
+
+    $AttachedUuidOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread "prefix$ThirdTestId"
+    $AttachedUuidJson = ($AttachedUuidOutput -join "`n") | ConvertFrom-Json
+    Assert-Condition ($LASTEXITCODE -ne 0 -and $AttachedUuidJson.Status -eq 'thread_invalid') 'attached_uuid_rejected'
+
+    $DecoratedUriOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread "codex://threads/${FourthTestId}?view=full"
+    $DecoratedUriJson = ($DecoratedUriOutput -join "`n") | ConvertFrom-Json
+    Assert-Condition ($LASTEXITCODE -ne 0 -and $DecoratedUriJson.Status -eq 'thread_invalid') 'decorated_uri_rejected'
+
+    $OversizedThreadOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread ('x' * 4097)
+    $OversizedThreadJson = ($OversizedThreadOutput -join "`n") | ConvertFrom-Json
+    Assert-Condition ($LASTEXITCODE -ne 0 -and $OversizedThreadJson.Status -eq 'thread_invalid') 'oversized_thread_rejected'
+
+    $InvalidMessageOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $ThirdTestId -Message "A`nB"
+    $InvalidMessageJson = ($InvalidMessageOutput -join "`n") | ConvertFrom-Json
+    Assert-Condition ($LASTEXITCODE -ne 0 -and $InvalidMessageJson.Ok -eq $false) 'newline_message_rejected'
+
+    $LongMessage = 'あ' * 100
+    $LongMessageOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $FourthTestId -Message $LongMessage
+    $LongMessageJson = ($LongMessageOutput -join "`n") | ConvertFrom-Json
+    Assert-Condition ($LASTEXITCODE -ne 0 -and $LongMessageJson.Ok -eq $false) 'long_message_rejected'
+
+    $WatcherId = [Guid]::NewGuid().ToString('D').ToLowerInvariant()
+    $WatcherRollout = Join-Path $FixtureRoot "sessions\2026\01\rollout-2026-01-01T00-00-00-$WatcherId.jsonl"
+    New-TestTranscript -Path $WatcherRollout -ThreadId $WatcherId -IncludeOldComplete
+    Add-TestSessionIndexEntry -ThreadId $WatcherId
+    [Environment]::SetEnvironmentVariable('CODEX_HOME', $FixtureRoot, 'Process')
+    $WatcherStatePath = Join-Path $StateDirectory "requests\$WatcherId.json"
+    $WatcherCheckpointPath = Join-Path $StateDirectory "checkpoints\$WatcherId.json"
+    $WatcherTerminalPath = Join-Path $StateDirectory "terminal\$WatcherId.json"
+    foreach ($Path in @($WatcherStatePath, $WatcherCheckpointPath, $WatcherTerminalPath, (Join-Path $StateDirectory "locks\$WatcherId.lock"))) {
+        [void]$CreatedStatePaths.Add($Path)
+    }
+
+    $WatcherArmOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $WatcherId -Message 'watcher本文'
+    Assert-Condition ($LASTEXITCODE -eq 0) 'watcher_arm'
+    $WatcherOnce = & $PowerShellExecutable -NoProfile -NonInteractive -File $WatcherPath -Once
+    Assert-Condition ($LASTEXITCODE -eq 0 -and (Test-Path -LiteralPath $WatcherStatePath -PathType Leaf)) 'watcher_ignores_old_complete'
+
+    $PartialEvent = [ordered]@{
+        timestamp = [DateTimeOffset]::UtcNow.ToString('o')
+        type = 'event_msg'
+        payload = [ordered]@{
+            type = 'task_complete'
+            turn_id = $WatcherId
+        }
+    } | ConvertTo-Json -Compress
+    [IO.File]::AppendAllText($WatcherRollout, $PartialEvent.Substring(0, [Math]::Max(1, $PartialEvent.Length - 3)), [Text.UTF8Encoding]::new($false))
+    & $PowerShellExecutable -NoProfile -NonInteractive -File $WatcherPath -Once | Out-Null
+    Assert-Condition (Test-Path -LiteralPath $WatcherStatePath -PathType Leaf) 'watcher_ignores_partial_line'
+    [IO.File]::AppendAllText($WatcherRollout, $PartialEvent.Substring([Math]::Max(1, $PartialEvent.Length - 3)) + "`n", [Text.UTF8Encoding]::new($false))
+    & $PowerShellExecutable -NoProfile -NonInteractive -File $WatcherPath -Once | Out-Null
+    Assert-Condition (-not (Test-Path -LiteralPath $WatcherStatePath -PathType Leaf)) 'watcher_consumes_complete_line'
+    Assert-Condition ((Read-JsonFile -Path $WatcherTerminalPath).status -eq 'failure') 'watcher_terminal_failure'
+
+    $ResidentRollout = Join-Path $FixtureRoot "sessions\2026\01\rollout-2026-01-01T00-00-00-$ResidentTestId.jsonl"
+    New-TestTranscript -Path $ResidentRollout -ThreadId $ResidentTestId
+    Add-TestSessionIndexEntry -ThreadId $ResidentTestId
+    $ResidentStatePath = Join-Path $StateDirectory "requests\$ResidentTestId.json"
+    $ResidentCheckpointPath = Join-Path $StateDirectory "checkpoints\$ResidentTestId.json"
+    $ResidentTerminalPath = Join-Path $StateDirectory "terminal\$ResidentTestId.json"
+    foreach ($Path in @($ResidentStatePath, $ResidentCheckpointPath, $ResidentTerminalPath, (Join-Path $StateDirectory "locks\$ResidentTestId.lock"))) {
+        [void]$CreatedStatePaths.Add($Path)
+    }
+    $ResidentArmOutput = & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $ResidentTestId -Message '常駐待機'
+    Assert-Condition ($LASTEXITCODE -eq 0) 'resident_arm'
+    $ResidentProcess = Start-DetachedPowerShell `
+        -ScriptPath $WatcherPath `
+        -Arguments @('-PollIntervalMilliseconds', '100')
+    Start-Sleep -Milliseconds 500
+    $ResidentProcess.Refresh()
+    Assert-Condition (-not $ResidentProcess.HasExited) 'resident_watcher_waits'
+    $ResidentEvent = [ordered]@{
+        timestamp = [DateTimeOffset]::UtcNow.ToString('o')
+        type = 'event_msg'
+        payload = [ordered]@{
+            type = 'task_complete'
+            turn_id = $ResidentTestId
+        }
+    } | ConvertTo-Json -Compress
+    [IO.File]::AppendAllText($ResidentRollout, "$ResidentEvent`n", [Text.UTF8Encoding]::new($false))
+    $ResidentDeadline = [DateTimeOffset]::UtcNow.AddSeconds(60)
+    while ($true) {
+        $ResidentProcess.Refresh()
+        if ($ResidentProcess.HasExited -or [DateTimeOffset]::UtcNow -ge $ResidentDeadline) {
+            break
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    $ResidentProcess.Refresh()
+    Assert-Condition $ResidentProcess.HasExited 'resident_watcher_consumes'
+    [void]$ResidentProcess.WaitForExit()
+    Assert-Condition (-not (Test-Path -LiteralPath $ResidentStatePath -PathType Leaf)) 'resident_consumes_active'
+    Assert-Condition ((Read-JsonFile -Path $ResidentTerminalPath).status -eq 'failure') 'resident_terminal_failure'
+    $ResidentProcess.Dispose()
+    $ResidentProcess = $null
+
+    $TransientRollout = Join-Path $FixtureRoot "sessions\2026\01\rollout-2026-01-01T00-00-00-$TransientTestId.jsonl"
+    New-TestTranscript -Path $TransientRollout -ThreadId $TransientTestId
+    Add-TestSessionIndexEntry -ThreadId $TransientTestId
+    $TransientStatePath = Join-Path $StateDirectory "requests\$TransientTestId.json"
+    $TransientCheckpointPath = Join-Path $StateDirectory "checkpoints\$TransientTestId.json"
+    $TransientTerminalPath = Join-Path $StateDirectory "terminal\$TransientTestId.json"
+    foreach ($Path in @($TransientStatePath, $TransientCheckpointPath, $TransientTerminalPath, (Join-Path $StateDirectory "locks\$TransientTestId.lock"))) {
+        [void]$CreatedStatePaths.Add($Path)
+    }
+    & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $TransientTestId -Message '一時失敗' | Out-Null
+    Assert-Condition ($LASTEXITCODE -eq 0) 'transient_arm'
+    $TransientState = Read-JsonFile -Path $TransientStatePath
+    $TransientCheckpoint = Read-JsonFile -Path $TransientCheckpointPath
+    $TransientBaselineEntry = @($TransientCheckpoint.files | Where-Object { $_.path -eq $TransientRollout })[0]
+    Assert-Condition ($null -ne $TransientBaselineEntry) 'transient_baseline_entry'
+    $TransientBaselineOffset = [long]$TransientBaselineEntry.offset
+    $TransientEvent = [ordered]@{
+        timestamp = [DateTimeOffset]::UtcNow.ToString('o')
+        type = 'event_msg'
+        payload = [ordered]@{
+            type = 'task_complete'
+            turn_id = $TransientTestId
+        }
+    } | ConvertTo-Json -Compress
+    [IO.File]::AppendAllText($TransientRollout, "$TransientEvent`n", [Text.UTF8Encoding]::new($false))
+    $MissingHelperPath = Join-Path $FixtureRoot 'missing-helper.ps1'
+    & $PowerShellExecutable -NoProfile -NonInteractive -File $WatcherPath -Once -HelperScriptPath $MissingHelperPath | Out-Null
+    Assert-Condition ($LASTEXITCODE -eq 0 -and (Test-Path -LiteralPath $TransientStatePath -PathType Leaf)) 'transient_keeps_active'
+    $TransientAfterCheckpoint = Read-JsonFile -Path $TransientCheckpointPath
+    $TransientAfterEntry = @($TransientAfterCheckpoint.files | Where-Object { $_.path -eq $TransientRollout })[0]
+    Assert-Condition ($TransientAfterCheckpoint.generation -eq $TransientState.generation) 'transient_generation_preserved'
+    Assert-Condition ([long]$TransientAfterEntry.offset -eq $TransientBaselineOffset) 'transient_offset_preserved'
+    & $PowerShellExecutable -NoProfile -NonInteractive -File $WatcherPath -Once | Out-Null
+    Assert-Condition (-not (Test-Path -LiteralPath $TransientStatePath -PathType Leaf)) 'transient_recovered'
+    Assert-Condition ((Read-JsonFile -Path $TransientTerminalPath).status -eq 'failure') 'transient_terminal_failure'
+
+    $NotHandledRollout = Join-Path $FixtureRoot "sessions\2026\01\rollout-2026-01-01T00-00-00-$NotHandledTestId.jsonl"
+    New-TestTranscript -Path $NotHandledRollout -ThreadId $NotHandledTestId
+    Add-TestSessionIndexEntry -ThreadId $NotHandledTestId
+    $NotHandledStatePath = Join-Path $StateDirectory "requests\$NotHandledTestId.json"
+    $NotHandledCheckpointPath = Join-Path $StateDirectory "checkpoints\$NotHandledTestId.json"
+    $NotHandledTerminalPath = Join-Path $StateDirectory "terminal\$NotHandledTestId.json"
+    foreach ($Path in @($NotHandledStatePath, $NotHandledCheckpointPath, $NotHandledTerminalPath, (Join-Path $StateDirectory "locks\$NotHandledTestId.lock"))) {
+        [void]$CreatedStatePaths.Add($Path)
+    }
+    & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $NotHandledTestId -Message '未処理保持' | Out-Null
+    Assert-Condition ($LASTEXITCODE -eq 0) 'not_handled_arm'
+    $NotHandledState = Read-JsonFile -Path $NotHandledStatePath
+    $NotHandledCheckpoint = Read-JsonFile -Path $NotHandledCheckpointPath
+    $NotHandledBaselineEntry = @($NotHandledCheckpoint.files | Where-Object { $_.path -eq $NotHandledRollout })[0]
+    Assert-Condition ($null -ne $NotHandledBaselineEntry) 'not_handled_baseline_entry'
+    $NotHandledBaselineOffset = [long]$NotHandledBaselineEntry.offset
+    $NotHandledEvent = [ordered]@{
+        timestamp = [DateTimeOffset]::UtcNow.ToString('o')
+        type = 'event_msg'
+        payload = [ordered]@{
+            type = 'task_complete'
+            turn_id = $NotHandledTestId
+        }
+    } | ConvertTo-Json -Compress
+    [IO.File]::AppendAllText($NotHandledRollout, "$NotHandledEvent`n", [Text.UTF8Encoding]::new($false))
+    $NotHandledHelperPath = Join-Path $FixtureRoot 'not-handled-helper.ps1'
+    $NotHandledHelperText = @'
+#requires -Version 7.4
+[Console]::In.ReadToEnd() | Out-Null
+[Console]::Out.WriteLine('{"Ok":true,"Handled":false}')
+'@
+    [IO.File]::WriteAllText($NotHandledHelperPath, $NotHandledHelperText, [Text.UTF8Encoding]::new($false))
+    & $PowerShellExecutable -NoProfile -NonInteractive -File $WatcherPath -Once -HelperScriptPath $NotHandledHelperPath | Out-Null
+    Assert-Condition ($LASTEXITCODE -eq 0 -and (Test-Path -LiteralPath $NotHandledStatePath -PathType Leaf)) 'not_handled_keeps_active'
+    $NotHandledAfterCheckpoint = Read-JsonFile -Path $NotHandledCheckpointPath
+    $NotHandledAfterEntry = @($NotHandledAfterCheckpoint.files | Where-Object { $_.path -eq $NotHandledRollout })[0]
+    Assert-Condition ([long]$NotHandledAfterEntry.offset -eq $NotHandledBaselineOffset) 'not_handled_offset_preserved'
+    & $PowerShellExecutable -NoProfile -NonInteractive -File $WatcherPath -Once | Out-Null
+    Assert-Condition (-not (Test-Path -LiteralPath $NotHandledStatePath -PathType Leaf)) 'not_handled_recovered'
+    Assert-Condition ((Read-JsonFile -Path $NotHandledTerminalPath).status -eq 'failure') 'not_handled_terminal_failure'
+
+    $GenerationRollout = Join-Path $FixtureRoot "sessions\2026\01\rollout-2026-01-01T00-00-00-$GenerationTestId.jsonl"
+    New-TestTranscript -Path $GenerationRollout -ThreadId $GenerationTestId
+    Add-TestSessionIndexEntry -ThreadId $GenerationTestId
+    $GenerationStatePath = Join-Path $StateDirectory "requests\$GenerationTestId.json"
+    $GenerationCheckpointPath = Join-Path $StateDirectory "checkpoints\$GenerationTestId.json"
+    $GenerationTerminalPath = Join-Path $StateDirectory "terminal\$GenerationTestId.json"
+    foreach ($Path in @($GenerationStatePath, $GenerationCheckpointPath, $GenerationTerminalPath, (Join-Path $StateDirectory "locks\$GenerationTestId.lock"))) {
+        [void]$CreatedStatePaths.Add($Path)
+    }
+    & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $GenerationTestId -Message '世代A' | Out-Null
+    Assert-Condition ($LASTEXITCODE -eq 0) 'generation_arm_a'
+    $GenerationStateA = Read-JsonFile -Path $GenerationStatePath
+    $GenerationAttempting = [ordered]@{
+        schemaVersion = $GenerationStateA.schemaVersion
+        provider = $GenerationStateA.provider
+        generation = $GenerationStateA.generation
+        status = 'attempting'
+        target = [ordered]@{ threadId = $GenerationTestId }
+        event = [ordered]@{ turnId = $GenerationTestId }
+        claimedAtUtc = [DateTimeOffset]::UtcNow.ToString('o')
+    }
+    [IO.File]::WriteAllText($GenerationStatePath, ($GenerationAttempting | ConvertTo-Json -Depth 20 -Compress), [Text.UTF8Encoding]::new($false))
+    & $PowerShellExecutable -NoProfile -NonInteractive -File $ArmPath -Thread $GenerationTestId -Message '世代B' | Out-Null
+    Assert-Condition ($LASTEXITCODE -eq 0) 'generation_arm_b'
+    $GenerationStateB = Read-JsonFile -Path $GenerationStatePath
+    Assert-Condition ($GenerationStateA.generation -ne $GenerationStateB.generation) 'generation_rotated'
+    $StaleCheckpoint = [ordered]@{
+        schemaVersion = 1
+        provider = 'codex'
+        generation = $GenerationStateA.generation
+        target = [ordered]@{ threadId = $GenerationTestId }
+        armedAtUtc = $GenerationStateA.armedAtUtc
+        files = @(
+            [ordered]@{
+                path = $GenerationRollout
+                offset = 0
+            }
+        )
+    }
+    [IO.File]::WriteAllText($GenerationCheckpointPath, ($StaleCheckpoint | ConvertTo-Json -Depth 20 -Compress), [Text.UTF8Encoding]::new($false))
+    & $PowerShellExecutable -NoProfile -NonInteractive -File $WatcherPath -Once | Out-Null
+    $GenerationAfterCheckpoint = Read-JsonFile -Path $GenerationCheckpointPath
+    Assert-Condition ($GenerationAfterCheckpoint.generation -eq $GenerationStateB.generation) 'stale_generation_replaced'
+
+    [Console]::Out.WriteLine('task-complete-notify tests: PASS')
+}
+catch {
+    if ($_.Exception.Message -match '^assert_failed:[A-Za-z0-9_]+$') {
+        [Console]::Error.WriteLine("task-complete-notify tests: FAIL ($($_.Exception.Message))")
+    }
+    else {
+        [Console]::Error.WriteLine("task-complete-notify tests: FAIL (unexpected:$($_.Exception.GetType().Name):line$($_.InvocationInfo.ScriptLineNumber))")
+    }
+    exit 1
+}
+finally {
+    if ($null -ne $ResidentProcess) {
+        try {
+            $ResidentProcess.Refresh()
+            if (-not $ResidentProcess.HasExited) {
+                $ResidentProcess.Kill($true)
+                [void]$ResidentProcess.WaitForExit()
+            }
+        }
+        catch {
+            # The resident test child may already have exited or been cleaned up.
+        }
+        finally {
+            $ResidentProcess.Dispose()
+            $ResidentProcess = $null
+        }
+    }
+    Remove-TestState
+    if ($null -eq $OriginalNtfyTopic) {
+        [Environment]::SetEnvironmentVariable('NTFY_TOPIC', $null, 'Process')
+    }
+    else {
+        [Environment]::SetEnvironmentVariable('NTFY_TOPIC', $OriginalNtfyTopic, 'Process')
+    }
+    if ($null -eq $OriginalCodexHome) {
+        [Environment]::SetEnvironmentVariable('CODEX_HOME', $null, 'Process')
+    }
+    else {
+        [Environment]::SetEnvironmentVariable('CODEX_HOME', $OriginalCodexHome, 'Process')
+    }
+    if ($null -eq $OriginalWatcherMode) {
+        [Environment]::SetEnvironmentVariable('TASK_COMPLETE_NOTIFY_WATCHER', $null, 'Process')
+    }
+    else {
+        [Environment]::SetEnvironmentVariable('TASK_COMPLETE_NOTIFY_WATCHER', $OriginalWatcherMode, 'Process')
+    }
+    Remove-Item -LiteralPath $FixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

Related issue: #3

- Merge the latest `master` (`b64e873`) before implementation.
- Relocate the skill to the canonical `link-targets/agents/skills/task-complete-notify` tree.
- Add a request-owned, armed-only absolute 24-hour TTL. Missing, malformed, offset-less, or overflowing timestamps fail closed; the request timestamp is authoritative and cleanup is lazy.
- Add an explicit-thread cancel route with coordination/per-thread locking, request-first cleanup, idempotent `not_armed` results, `too_late` for an observed in-flight claim, and no cancellation history or message/topic leakage.
- Preserve the existing arm command, Stop-primary / watcher-fallback architecture, one-shot generation semantics, ownership checks, and privacy boundaries.
- Add contract documentation, design rationale, regression coverage, race handling, watcher natural-exit coverage, and the offset-preservation regression fix.

## Validation

- PowerShell 7.6.6 acceptance suite: `task-complete-notify tests: PASS`
- PowerShell parser: `PASS`
- Reference-map validator: `PASS`
- `git diff --check`: `PASS`
- Advisor implementation-slice review: `CLEAR`
- Advisor final whole-range review: `CLEAR`
- Claude Code 2.1.270 read-only final review: `CLEAR` (only low-severity maintenance observations; no blocker/high/medium findings)
- Stop-hook canary: the explicit thread was armed, the production wrapper returned exit 0 with no stdout, active state was consumed with terminal `success`, and the notification was confirmed delivered at 2026-09-16 15:57 JST.

## Enablement note

This PR does not edit Codex configuration automatically. Hook registration remains a separate manual operation after reviewing `references/codex-hooks.json` and the active permission profile. The canary exercised the production Stop-hook path with a controlled completion input; normal operation sends on the next real Codex `Stop` event, not directly on Claude subprocess exit.